### PR TITLE
Add .caseless subfield to process.name & process.executable

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Added `.caseless` subfield to `process.name` and `process.executable`. #2341
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8128,6 +8128,9 @@ type: keyword
 
 Multi-fields:
 
+* process.executable.caseless (type: keyword)
+
+
 * process.executable.text (type: match_only_text)
 
 
@@ -8342,6 +8345,9 @@ Sometimes called program name or similar.
 type: keyword
 
 Multi-fields:
+
+* process.name.caseless (type: keyword)
+
 
 * process.name.text (type: match_only_text)
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1509,7 +1509,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -3118,7 +3118,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -5175,10 +5175,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5217,10 +5213,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5432,10 +5424,9 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       default_field: false
     - name: entry_leader.user.id
@@ -5491,11 +5482,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5562,10 +5548,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5604,10 +5586,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5741,10 +5719,9 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       default_field: false
     - name: group_leader.user.id
@@ -6023,11 +6000,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6417,10 +6389,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6664,10 +6632,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -6803,7 +6767,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: parent.pe.sections
       level: extended
@@ -6998,10 +6962,9 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       default_field: false
     - name: parent.uptime
@@ -7176,7 +7139,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -7255,10 +7218,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7374,10 +7333,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7416,10 +7371,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7631,10 +7582,9 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       default_field: false
     - name: session_leader.user.id
@@ -7753,10 +7703,9 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       default_field: false
     - name: tty.columns
@@ -9045,12 +8994,12 @@
     title: Threat
     group: 2
     description: "Fields to classify events and alerts according to a threat taxonomy\
-      \ such as the MITRE ATT&CK\xC2\xAE framework.\nThese fields are for users to\
-      \ classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a\
-      \ common taxonomy. The threat.tactic.* fields are meant to capture the high\
-      \ level category of the threat (e.g. \"impact\"). The threat.technique.* fields\
-      \ are meant to capture which kind of approach is used by this detected threat,\
-      \ to accomplish the goal (e.g. \"endpoint denial of service\")."
+      \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
+      \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
+      \ The threat.tactic.* fields are meant to capture the high level category of\
+      \ the threat (e.g. \"impact\"). The threat.technique.* fields are meant to capture\
+      \ which kind of approach is used by this detected threat, to accomplish the\
+      \ goal (e.g. \"endpoint denial of service\")."
     type: group
     default_field: true
     fields:
@@ -9754,7 +9703,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: enrichments.indicator.file.pe.sections
       level: extended
@@ -10642,7 +10591,7 @@
       ignore_above: 1024
       description: "The alias(es) of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       default_field: false
     - name: group.id
@@ -10651,7 +10600,7 @@
       ignore_above: 1024
       description: "The id of the group for a set of related intrusion activity that\
         \ are tracked by a common name in the security community.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xC2\xAE group id."
+        \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       default_field: false
     - name: group.name
@@ -10660,7 +10609,7 @@
       ignore_above: 1024
       description: "The name of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE group name."
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       default_field: false
     - name: group.reference
@@ -10669,7 +10618,7 @@
       ignore_above: 1024
       description: "The reference URL of the group for a set of related intrusion\
         \ activity that are tracked by a common name in the security community.\n\
-        While not required, you can use a MITRE ATT&CK\xC2\xAE group reference URL."
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       default_field: false
     - name: indicator.as.number
@@ -11361,7 +11310,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: indicator.file.pe.sections
       level: extended
@@ -11701,10 +11650,10 @@
       type: keyword
       ignore_above: 1024
       description: "The ID of the indicator used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple\
-        \ values to allow for the identification of the same indicator across systems\
-        \ that use different ID formats.\nWhile not required, a common approach is\
-        \ to use a STIX 2.x indicator ID."
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator ID."
       example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
       default_field: false
     - name: indicator.ip
@@ -12178,7 +12127,7 @@
       ignore_above: 1024
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE associated software description."
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
       example: '[ "X-Agent" ]'
       default_field: false
     - name: software.id
@@ -12186,8 +12135,8 @@
       type: keyword
       ignore_above: 1024
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use a MITRE ATT&CK\xC2\xAE software id."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ a MITRE ATT&CK\xAE software id."
       example: S0552
       default_field: false
     - name: software.name
@@ -12195,8 +12144,8 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use a MITRE ATT&CK\xC2\xAE software name."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       default_field: false
     - name: software.platforms
@@ -12204,8 +12153,8 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use MITRE ATT&CK\xC2\xAE software platform values."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -12213,8 +12162,8 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xC2\xAE software reference URL."
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
+        \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       default_field: false
     - name: software.type
@@ -12222,38 +12171,38 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xC2\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
-        \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0002
     - name: tactic.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
       example: Execution
     - name: tactic.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0002/
     - name: technique.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
-        \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: T1059
     - name: technique.name
       level: extended
@@ -12264,21 +12213,21 @@
         type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: Command and Scripting Interpreter
     - name: technique.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: https://attack.mitre.org/techniques/T1059/
     - name: technique.subtechnique.id
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The full id of subtechnique used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: T1059.001
       default_field: false
     - name: technique.subtechnique.name
@@ -12289,7 +12238,7 @@
       - name: text
         type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
-        \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
       default_field: false
     - name: technique.subtechnique.reference
@@ -12297,7 +12246,7 @@
       type: keyword
       ignore_above: 1024
       description: "The reference url of subtechnique used by this threat. You can\
-        \ use a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       default_field: false
   - name: tls

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1509,7 +1509,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -3118,7 +3118,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -5175,6 +5175,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5213,6 +5217,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5424,9 +5432,10 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       default_field: false
     - name: entry_leader.user.id
@@ -5482,6 +5491,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5548,6 +5562,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5586,6 +5604,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5719,9 +5741,10 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       default_field: false
     - name: group_leader.user.id
@@ -6000,6 +6023,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6389,6 +6417,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6632,6 +6664,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -6767,7 +6803,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: parent.pe.sections
       level: extended
@@ -6962,9 +6998,10 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       default_field: false
     - name: parent.uptime
@@ -7139,7 +7176,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: pe.sections
       level: extended
@@ -7218,6 +7255,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7333,6 +7374,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7371,6 +7416,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7582,9 +7631,10 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       default_field: false
     - name: session_leader.user.id
@@ -7703,9 +7753,10 @@
       level: extended
       type: long
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       default_field: false
     - name: tty.columns
@@ -8994,12 +9045,12 @@
     title: Threat
     group: 2
     description: "Fields to classify events and alerts according to a threat taxonomy\
-      \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
-      \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
-      \ The threat.tactic.* fields are meant to capture the high level category of\
-      \ the threat (e.g. \"impact\"). The threat.technique.* fields are meant to capture\
-      \ which kind of approach is used by this detected threat, to accomplish the\
-      \ goal (e.g. \"endpoint denial of service\")."
+      \ such as the MITRE ATT&CK\xC2\xAE framework.\nThese fields are for users to\
+      \ classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a\
+      \ common taxonomy. The threat.tactic.* fields are meant to capture the high\
+      \ level category of the threat (e.g. \"impact\"). The threat.technique.* fields\
+      \ are meant to capture which kind of approach is used by this detected threat,\
+      \ to accomplish the goal (e.g. \"endpoint denial of service\")."
     type: group
     default_field: true
     fields:
@@ -9703,7 +9754,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: enrichments.indicator.file.pe.sections
       level: extended
@@ -10591,7 +10642,7 @@
       ignore_above: 1024
       description: "The alias(es) of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       default_field: false
     - name: group.id
@@ -10600,7 +10651,7 @@
       ignore_above: 1024
       description: "The id of the group for a set of related intrusion activity that\
         \ are tracked by a common name in the security community.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xAE group id."
+        \ you can use a MITRE ATT&CK\xC2\xAE group id."
       example: G0037
       default_field: false
     - name: group.name
@@ -10609,7 +10660,7 @@
       ignore_above: 1024
       description: "The name of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE group name."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE group name."
       example: FIN6
       default_field: false
     - name: group.reference
@@ -10618,7 +10669,7 @@
       ignore_above: 1024
       description: "The reference URL of the group for a set of related intrusion\
         \ activity that are tracked by a common name in the security community.\n\
-        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        While not required, you can use a MITRE ATT&CK\xC2\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       default_field: false
     - name: indicator.as.number
@@ -11310,7 +11361,7 @@
       type: keyword
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       default_field: false
     - name: indicator.file.pe.sections
       level: extended
@@ -11650,10 +11701,10 @@
       type: keyword
       ignore_above: 1024
       description: "The ID of the indicator used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
-        \ to allow for the identification of the same indicator across systems that\
-        \ use different ID formats.\nWhile not required, a common approach is to use\
-        \ a STIX 2.x indicator ID."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple\
+        \ values to allow for the identification of the same indicator across systems\
+        \ that use different ID formats.\nWhile not required, a common approach is\
+        \ to use a STIX 2.x indicator ID."
       example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
       default_field: false
     - name: indicator.ip
@@ -12127,7 +12178,7 @@
       ignore_above: 1024
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE associated software description."
       example: '[ "X-Agent" ]'
       default_field: false
     - name: software.id
@@ -12135,8 +12186,8 @@
       type: keyword
       ignore_above: 1024
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ a MITRE ATT&CK\xAE software id."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use a MITRE ATT&CK\xC2\xAE software id."
       example: S0552
       default_field: false
     - name: software.name
@@ -12144,8 +12195,8 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ a MITRE ATT&CK\xAE software name."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use a MITRE ATT&CK\xC2\xAE software name."
       example: AdFind
       default_field: false
     - name: software.platforms
@@ -12153,8 +12204,8 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ MITRE ATT&CK\xAE software platform values."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use MITRE ATT&CK\xC2\xAE software platform values."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -12162,8 +12213,8 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
-        \ can use a MITRE ATT&CK\xAE software reference URL."
+        \ behavior commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required,\
+        \ you can use a MITRE ATT&CK\xC2\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       default_field: false
     - name: software.type
@@ -12171,38 +12222,38 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xC2\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
+        \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0002
     - name: tactic.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
       example: Execution
     - name: tactic.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0002/
     - name: technique.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
+        \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: T1059
     - name: technique.name
       level: extended
@@ -12213,21 +12264,21 @@
         type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: Command and Scripting Interpreter
     - name: technique.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ a MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: https://attack.mitre.org/techniques/T1059/
     - name: technique.subtechnique.id
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The full id of subtechnique used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: T1059.001
       default_field: false
     - name: technique.subtechnique.name
@@ -12238,7 +12289,7 @@
       - name: text
         type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
       default_field: false
     - name: technique.subtechnique.reference
@@ -12246,7 +12297,7 @@
       type: keyword
       ignore_above: 1024
       description: "The reference url of subtechnique used by this threat. You can\
-        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ use a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       default_field: false
   - name: tls

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5175,6 +5175,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5213,6 +5217,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5482,6 +5490,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5548,6 +5561,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5586,6 +5603,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -6000,6 +6021,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6389,6 +6415,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6632,6 +6662,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7218,6 +7252,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7333,6 +7371,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7371,6 +7413,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -648,11 +648,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
 8.12.0-dev+exp,true,process,process.entry_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.entry_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.entry_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.entry_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.entry_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev+exp,true,process,process.entry_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.pid,long,core,,4242,Process id.
@@ -688,6 +690,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.12.0-dev+exp,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.12.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -696,11 +699,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.group_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.group_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.group_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.group_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.group_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev+exp,true,process,process.group_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.pid,long,core,,4242,Process id.
 8.12.0-dev+exp,true,process,process.group_leader.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -760,6 +765,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
+8.12.0-dev+exp,true,process,process.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -815,6 +821,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.end,date,extended,,2016-05-23T08:05:34.853Z,The time the process ended.
 8.12.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.parent.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.parent.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -848,6 +855,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
+8.12.0-dev+exp,true,process,process.parent.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.12.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -931,6 +939,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.previous.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.previous.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.real_group.name,keyword,extended,,,Name of the group.
@@ -948,11 +957,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.session_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev+exp,true,process,process.session_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.session_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.session_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.session_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev+exp,true,process,process.session_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.parent.pid,long,core,,4242,Process id.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -648,13 +648,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
 8.12.0-dev+exp,true,process,process.entry_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.entry_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.entry_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.entry_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.entry_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.entry_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.pid,long,core,,4242,Process id.
@@ -690,7 +688,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.12.0-dev+exp,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.12.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -699,13 +696,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.group_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.group_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.group_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.group_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.group_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.group_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.pid,long,core,,4242,Process id.
 8.12.0-dev+exp,true,process,process.group_leader.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -765,7 +760,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -821,7 +815,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.end,date,extended,,2016-05-23T08:05:34.853Z,The time the process ended.
 8.12.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.parent.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.parent.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -855,7 +848,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.parent.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.12.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -939,7 +931,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.previous.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.previous.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.real_group.name,keyword,extended,,,Name of the group.
@@ -957,13 +948,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.session_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.session_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.session_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.session_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.session_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.session_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.parent.pid,long,core,,4242,Process id.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2192,7 +2192,7 @@ dll.pe.pehash:
 dll.pe.product:
   dashed_name: dll-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: dll.pe.product
   ignore_above: 1024
   level: extended
@@ -5120,7 +5120,7 @@ file.pe.pehash:
 file.pe.product:
   dashed_name: file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: file.pe.product
   ignore_above: 1024
   level: extended
@@ -8426,6 +8426,11 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8487,6 +8492,11 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8816,9 +8826,9 @@ process.entry_leader.tty.char_device.major:
 process.entry_leader.tty.char_device.minor:
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
-    \ to the driver. It is common for a driver to control several devices; the minor\
-    \ number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
+    \ it along to the driver. It is common for a driver to control several devices;\
+    \ the minor number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.entry_leader.tty.char_device.minor
   level: extended
@@ -8910,6 +8920,11 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -9007,6 +9022,11 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -9068,6 +9088,11 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9279,9 +9304,9 @@ process.group_leader.tty.char_device.major:
 process.group_leader.tty.char_device.minor:
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
-    \ to the driver. It is common for a driver to control several devices; the minor\
-    \ number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
+    \ it along to the driver. It is common for a driver to control several devices;\
+    \ the minor number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.group_leader.tty.char_device.minor
   level: extended
@@ -9757,6 +9782,11 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10418,6 +10448,11 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10827,6 +10862,11 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11043,7 +11083,7 @@ process.parent.pe.pehash:
 process.parent.pe.product:
   dashed_name: process-parent-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: process.parent.pe.product
   ignore_above: 1024
   level: extended
@@ -11380,9 +11420,9 @@ process.parent.tty.char_device.major:
 process.parent.tty.char_device.minor:
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
-    \ to the driver. It is common for a driver to control several devices; the minor\
-    \ number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
+    \ it along to the driver. It is common for a driver to control several devices;\
+    \ the minor number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.parent.tty.char_device.minor
   level: extended
@@ -11670,7 +11710,7 @@ process.pe.pehash:
 process.pe.product:
   dashed_name: process-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: process.pe.product
   ignore_above: 1024
   level: extended
@@ -11811,6 +11851,11 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.previous.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -11996,6 +12041,11 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -12057,6 +12107,11 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text
@@ -12386,9 +12441,9 @@ process.session_leader.tty.char_device.major:
 process.session_leader.tty.char_device.minor:
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
-    \ to the driver. It is common for a driver to control several devices; the minor\
-    \ number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
+    \ it along to the driver. It is common for a driver to control several devices;\
+    \ the minor number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.session_leader.tty.char_device.minor
   level: extended
@@ -12582,9 +12637,9 @@ process.tty.char_device.major:
 process.tty.char_device.minor:
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
-    \ to the driver. It is common for a driver to control several devices; the minor\
-    \ number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
+    \ it along to the driver. It is common for a driver to control several devices;\
+    \ the minor number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.tty.char_device.minor
   level: extended
@@ -15663,7 +15718,7 @@ threat.enrichments.indicator.file.pe.pehash:
 threat.enrichments.indicator.file.pe.product:
   dashed_name: threat-enrichments-indicator-file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: threat.enrichments.indicator.file.pe.product
   ignore_above: 1024
   level: extended
@@ -17157,7 +17212,7 @@ threat.group.alias:
   dashed_name: threat-group-alias
   description: "The alias(es) of the group for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xAE group alias(es)."
+    \ you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
   example: '[ "Magecart Group 6" ]'
   flat_name: threat.group.alias
   ignore_above: 1024
@@ -17171,7 +17226,7 @@ threat.group.id:
   dashed_name: threat-group-id
   description: "The id of the group for a set of related intrusion activity that are\
     \ tracked by a common name in the security community.\nWhile not required, you\
-    \ can use a MITRE ATT&CK\xAE group id."
+    \ can use a MITRE ATT&CK\xC2\xAE group id."
   example: G0037
   flat_name: threat.group.id
   ignore_above: 1024
@@ -17184,7 +17239,7 @@ threat.group.name:
   dashed_name: threat-group-name
   description: "The name of the group for a set of related intrusion activity that\
     \ are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xAE group name."
+    \ you can use a MITRE ATT&CK\xC2\xAE group name."
   example: FIN6
   flat_name: threat.group.name
   ignore_above: 1024
@@ -17197,7 +17252,7 @@ threat.group.reference:
   dashed_name: threat-group-reference
   description: "The reference URL of the group for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xAE group reference URL."
+    \ you can use a MITRE ATT&CK\xC2\xAE group reference URL."
   example: https://attack.mitre.org/groups/G0037/
   flat_name: threat.group.reference
   ignore_above: 1024
@@ -18373,7 +18428,7 @@ threat.indicator.file.pe.pehash:
 threat.indicator.file.pe.product:
   dashed_name: threat-indicator-file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
+  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
   flat_name: threat.indicator.file.pe.product
   ignore_above: 1024
   level: extended
@@ -18963,7 +19018,7 @@ threat.indicator.geo.timezone:
 threat.indicator.id:
   dashed_name: threat-indicator-id
   description: "The ID of the indicator used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. This field can have multiple values to allow\
+    \ modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple values to allow\
     \ for the identification of the same indicator across systems that use different\
     \ ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator\
     \ ID."
@@ -19756,7 +19811,7 @@ threat.software.alias:
   dashed_name: threat-software-alias
   description: "The alias(es) of the software for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xAE associated software description."
+    \ you can use a MITRE ATT&CK\xC2\xAE associated software description."
   example: '[ "X-Agent" ]'
   flat_name: threat.software.alias
   ignore_above: 1024
@@ -19769,8 +19824,8 @@ threat.software.alias:
 threat.software.id:
   dashed_name: threat-software-id
   description: "The id of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
-    \ software id."
+    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
+    \ ATT&CK\xC2\xAE software id."
   example: S0552
   flat_name: threat.software.id
   ignore_above: 1024
@@ -19782,8 +19837,8 @@ threat.software.id:
 threat.software.name:
   dashed_name: threat-software-name
   description: "The name of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
-    \ software name."
+    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
+    \ ATT&CK\xC2\xAE software name."
   example: AdFind
   flat_name: threat.software.name
   ignore_above: 1024
@@ -19795,8 +19850,8 @@ threat.software.name:
 threat.software.platforms:
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use MITRE\
-    \ ATT&CK\xAE software platform values."
+    \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use\
+    \ MITRE ATT&CK\xC2\xAE software platform values."
   example: '[ "Windows" ]'
   expected_values:
   - AWS
@@ -19820,8 +19875,8 @@ threat.software.platforms:
 threat.software.reference:
   dashed_name: threat-software-reference
   description: "The reference URL of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a\
-    \ MITRE ATT&CK\xAE software reference URL."
+    \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use\
+    \ a MITRE ATT&CK\xC2\xAE software reference URL."
   example: https://attack.mitre.org/software/S0552/
   flat_name: threat.software.reference
   ignore_above: 1024
@@ -19833,8 +19888,8 @@ threat.software.reference:
 threat.software.type:
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
-    \ software type."
+    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
+    \ ATT&CK\xC2\xAE software type."
   example: Tool
   expected_values:
   - Malware
@@ -19848,8 +19903,8 @@ threat.software.type:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
+    \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
   example: TA0002
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -19862,7 +19917,7 @@ threat.tactic.id:
 threat.tactic.name:
   dashed_name: threat-tactic-name
   description: "Name of the type of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+    \ ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
   example: Execution
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -19875,7 +19930,7 @@ threat.tactic.name:
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
   description: "The reference url of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+    \ ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
     \ )"
   example: https://attack.mitre.org/tactics/TA0002/
   flat_name: threat.tactic.reference
@@ -19888,8 +19943,8 @@ threat.tactic.reference:
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
+    \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: T1059
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -19901,8 +19956,8 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xC2\
+    \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: Command and Scripting Interpreter
   flat_name: threat.technique.name
   ignore_above: 1024
@@ -19919,7 +19974,7 @@ threat.technique.name:
 threat.technique.reference:
   dashed_name: threat-technique-reference
   description: "The reference url of technique used by this threat. You can use a\
-    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+    \ MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: https://attack.mitre.org/techniques/T1059/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -19932,7 +19987,7 @@ threat.technique.reference:
 threat.technique.subtechnique.id:
   dashed_name: threat-technique-subtechnique-id
   description: "The full id of subtechnique used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: T1059.001
   flat_name: threat.technique.subtechnique.id
   ignore_above: 1024
@@ -19945,7 +20000,7 @@ threat.technique.subtechnique.id:
 threat.technique.subtechnique.name:
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: PowerShell
   flat_name: threat.technique.subtechnique.name
   ignore_above: 1024
@@ -19962,7 +20017,7 @@ threat.technique.subtechnique.name:
 threat.technique.subtechnique.reference:
   dashed_name: threat-technique-subtechnique-reference
   description: "The reference url of subtechnique used by this threat. You can use\
-    \ a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: https://attack.mitre.org/techniques/T1059/001/
   flat_name: threat.technique.subtechnique.reference
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8426,6 +8426,11 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8487,6 +8492,11 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8910,6 +8920,11 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -9007,6 +9022,11 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -9068,6 +9088,11 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9757,6 +9782,11 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10418,6 +10448,11 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10827,6 +10862,11 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11811,6 +11851,11 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.previous.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -11996,6 +12041,11 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -12057,6 +12107,11 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2192,7 +2192,7 @@ dll.pe.pehash:
 dll.pe.product:
   dashed_name: dll-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: dll.pe.product
   ignore_above: 1024
   level: extended
@@ -5120,7 +5120,7 @@ file.pe.pehash:
 file.pe.product:
   dashed_name: file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: file.pe.product
   ignore_above: 1024
   level: extended
@@ -8426,11 +8426,6 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8492,11 +8487,6 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8826,9 +8816,9 @@ process.entry_leader.tty.char_device.major:
 process.entry_leader.tty.char_device.minor:
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
-    \ it along to the driver. It is common for a driver to control several devices;\
-    \ the minor number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
+    \ to the driver. It is common for a driver to control several devices; the minor\
+    \ number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.entry_leader.tty.char_device.minor
   level: extended
@@ -8920,11 +8910,6 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -9022,11 +9007,6 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -9088,11 +9068,6 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9304,9 +9279,9 @@ process.group_leader.tty.char_device.major:
 process.group_leader.tty.char_device.minor:
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
-    \ it along to the driver. It is common for a driver to control several devices;\
-    \ the minor number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
+    \ to the driver. It is common for a driver to control several devices; the minor\
+    \ number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.group_leader.tty.char_device.minor
   level: extended
@@ -9782,11 +9757,6 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10448,11 +10418,6 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10862,11 +10827,6 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11083,7 +11043,7 @@ process.parent.pe.pehash:
 process.parent.pe.product:
   dashed_name: process-parent-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: process.parent.pe.product
   ignore_above: 1024
   level: extended
@@ -11420,9 +11380,9 @@ process.parent.tty.char_device.major:
 process.parent.tty.char_device.minor:
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
-    \ it along to the driver. It is common for a driver to control several devices;\
-    \ the minor number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
+    \ to the driver. It is common for a driver to control several devices; the minor\
+    \ number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.parent.tty.char_device.minor
   level: extended
@@ -11710,7 +11670,7 @@ process.pe.pehash:
 process.pe.product:
   dashed_name: process-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: process.pe.product
   ignore_above: 1024
   level: extended
@@ -11851,11 +11811,6 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.previous.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -12041,11 +11996,6 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -12107,11 +12057,6 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text
@@ -12441,9 +12386,9 @@ process.session_leader.tty.char_device.major:
 process.session_leader.tty.char_device.minor:
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
-    \ it along to the driver. It is common for a driver to control several devices;\
-    \ the minor number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
+    \ to the driver. It is common for a driver to control several devices; the minor\
+    \ number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.session_leader.tty.char_device.minor
   level: extended
@@ -12637,9 +12582,9 @@ process.tty.char_device.major:
 process.tty.char_device.minor:
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
-    \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely pass\
-    \ it along to the driver. It is common for a driver to control several devices;\
-    \ the minor number provides a way for the driver to differentiate among them."
+    \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
+    \ to the driver. It is common for a driver to control several devices; the minor\
+    \ number provides a way for the driver to differentiate among them."
   example: 1
   flat_name: process.tty.char_device.minor
   level: extended
@@ -15718,7 +15663,7 @@ threat.enrichments.indicator.file.pe.pehash:
 threat.enrichments.indicator.file.pe.product:
   dashed_name: threat-enrichments-indicator-file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: threat.enrichments.indicator.file.pe.product
   ignore_above: 1024
   level: extended
@@ -17212,7 +17157,7 @@ threat.group.alias:
   dashed_name: threat-group-alias
   description: "The alias(es) of the group for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
+    \ you can use a MITRE ATT&CK\xAE group alias(es)."
   example: '[ "Magecart Group 6" ]'
   flat_name: threat.group.alias
   ignore_above: 1024
@@ -17226,7 +17171,7 @@ threat.group.id:
   dashed_name: threat-group-id
   description: "The id of the group for a set of related intrusion activity that are\
     \ tracked by a common name in the security community.\nWhile not required, you\
-    \ can use a MITRE ATT&CK\xC2\xAE group id."
+    \ can use a MITRE ATT&CK\xAE group id."
   example: G0037
   flat_name: threat.group.id
   ignore_above: 1024
@@ -17239,7 +17184,7 @@ threat.group.name:
   dashed_name: threat-group-name
   description: "The name of the group for a set of related intrusion activity that\
     \ are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xC2\xAE group name."
+    \ you can use a MITRE ATT&CK\xAE group name."
   example: FIN6
   flat_name: threat.group.name
   ignore_above: 1024
@@ -17252,7 +17197,7 @@ threat.group.reference:
   dashed_name: threat-group-reference
   description: "The reference URL of the group for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xC2\xAE group reference URL."
+    \ you can use a MITRE ATT&CK\xAE group reference URL."
   example: https://attack.mitre.org/groups/G0037/
   flat_name: threat.group.reference
   ignore_above: 1024
@@ -18428,7 +18373,7 @@ threat.indicator.file.pe.pehash:
 threat.indicator.file.pe.product:
   dashed_name: threat-indicator-file-pe-product
   description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+  example: "Microsoft\xAE Windows\xAE Operating System"
   flat_name: threat.indicator.file.pe.product
   ignore_above: 1024
   level: extended
@@ -19018,7 +18963,7 @@ threat.indicator.geo.timezone:
 threat.indicator.id:
   dashed_name: threat-indicator-id
   description: "The ID of the indicator used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple values to allow\
+    \ modeled using MITRE ATT&CK\xAE. This field can have multiple values to allow\
     \ for the identification of the same indicator across systems that use different\
     \ ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator\
     \ ID."
@@ -19811,7 +19756,7 @@ threat.software.alias:
   dashed_name: threat-software-alias
   description: "The alias(es) of the software for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
-    \ you can use a MITRE ATT&CK\xC2\xAE associated software description."
+    \ you can use a MITRE ATT&CK\xAE associated software description."
   example: '[ "X-Agent" ]'
   flat_name: threat.software.alias
   ignore_above: 1024
@@ -19824,8 +19769,8 @@ threat.software.alias:
 threat.software.id:
   dashed_name: threat-software-id
   description: "The id of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
-    \ ATT&CK\xC2\xAE software id."
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software id."
   example: S0552
   flat_name: threat.software.id
   ignore_above: 1024
@@ -19837,8 +19782,8 @@ threat.software.id:
 threat.software.name:
   dashed_name: threat-software-name
   description: "The name of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
-    \ ATT&CK\xC2\xAE software name."
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software name."
   example: AdFind
   flat_name: threat.software.name
   ignore_above: 1024
@@ -19850,8 +19795,8 @@ threat.software.name:
 threat.software.platforms:
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use\
-    \ MITRE ATT&CK\xC2\xAE software platform values."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use MITRE\
+    \ ATT&CK\xAE software platform values."
   example: '[ "Windows" ]'
   expected_values:
   - AWS
@@ -19875,8 +19820,8 @@ threat.software.platforms:
 threat.software.reference:
   dashed_name: threat-software-reference
   description: "The reference URL of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use\
-    \ a MITRE ATT&CK\xC2\xAE software reference URL."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a\
+    \ MITRE ATT&CK\xAE software reference URL."
   example: https://attack.mitre.org/software/S0552/
   flat_name: threat.software.reference
   ignore_above: 1024
@@ -19888,8 +19833,8 @@ threat.software.reference:
 threat.software.type:
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
-    \ ATT&CK\xC2\xAE software type."
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software type."
   example: Tool
   expected_values:
   - Malware
@@ -19903,8 +19848,8 @@ threat.software.type:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
-    \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
   example: TA0002
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -19917,7 +19862,7 @@ threat.tactic.id:
 threat.tactic.name:
   dashed_name: threat-tactic-name
   description: "Name of the type of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
   example: Execution
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -19930,7 +19875,7 @@ threat.tactic.name:
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
   description: "The reference url of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
     \ )"
   example: https://attack.mitre.org/tactics/TA0002/
   flat_name: threat.tactic.reference
@@ -19943,8 +19888,8 @@ threat.tactic.reference:
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
-    \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: T1059
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -19956,8 +19901,8 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xC2\
-    \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: Command and Scripting Interpreter
   flat_name: threat.technique.name
   ignore_above: 1024
@@ -19974,7 +19919,7 @@ threat.technique.name:
 threat.technique.reference:
   dashed_name: threat-technique-reference
   description: "The reference url of technique used by this threat. You can use a\
-    \ MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
   example: https://attack.mitre.org/techniques/T1059/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -19987,7 +19932,7 @@ threat.technique.reference:
 threat.technique.subtechnique.id:
   dashed_name: threat-technique-subtechnique-id
   description: "The full id of subtechnique used by this threat. You can use a MITRE\
-    \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: T1059.001
   flat_name: threat.technique.subtechnique.id
   ignore_above: 1024
@@ -20000,7 +19945,7 @@ threat.technique.subtechnique.id:
 threat.technique.subtechnique.name:
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
-    \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: PowerShell
   flat_name: threat.technique.subtechnique.name
   ignore_above: 1024
@@ -20017,7 +19962,7 @@ threat.technique.subtechnique.name:
 threat.technique.subtechnique.reference:
   dashed_name: threat-technique-subtechnique-reference
   description: "The reference url of subtechnique used by this threat. You can use\
-    \ a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+    \ a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
   example: https://attack.mitre.org/techniques/T1059/001/
   flat_name: threat.technique.subtechnique.reference
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10636,6 +10636,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10697,6 +10702,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11120,6 +11130,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11217,6 +11232,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11278,6 +11298,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -11971,6 +11996,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12633,6 +12663,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -13043,6 +13078,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -14029,6 +14069,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.previous.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14214,6 +14259,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14275,6 +14325,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2666,7 +2666,7 @@ dll:
     dll.pe.product:
       dashed_name: dll-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: dll.pe.product
       ignore_above: 1024
       level: extended
@@ -6156,7 +6156,7 @@ file:
     file.pe.product:
       dashed_name: file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: file.pe.product
       ignore_above: 1024
       level: extended
@@ -9758,7 +9758,7 @@ pe:
     pe.product:
       dashed_name: pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: pe.product
       ignore_above: 1024
       level: extended
@@ -10636,11 +10636,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10702,11 +10697,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11036,10 +11026,9 @@ process:
     process.entry_leader.tty.char_device.minor:
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       flat_name: process.entry_leader.tty.char_device.minor
       level: extended
@@ -11131,11 +11120,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11233,11 +11217,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11299,11 +11278,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -11515,10 +11489,9 @@ process:
     process.group_leader.tty.char_device.minor:
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       flat_name: process.group_leader.tty.char_device.minor
       level: extended
@@ -11998,11 +11971,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12665,11 +12633,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -13080,11 +13043,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -13302,7 +13260,7 @@ process:
     process.parent.pe.product:
       dashed_name: process-parent-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: process.parent.pe.product
       ignore_above: 1024
       level: extended
@@ -13639,10 +13597,9 @@ process:
     process.parent.tty.char_device.minor:
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       flat_name: process.parent.tty.char_device.minor
       level: extended
@@ -13931,7 +13888,7 @@ process:
     process.pe.product:
       dashed_name: process-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: process.pe.product
       ignore_above: 1024
       level: extended
@@ -14072,11 +14029,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.previous.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14262,11 +14214,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14328,11 +14275,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text
@@ -14662,10 +14604,9 @@ process:
     process.session_leader.tty.char_device.minor:
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       flat_name: process.session_leader.tty.char_device.minor
       level: extended
@@ -14859,10 +14800,9 @@ process:
     process.tty.char_device.minor:
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
-        \ pass it along to the driver. It is common for a driver to control several\
-        \ devices; the minor number provides a way for the driver to differentiate\
-        \ among them."
+        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
+        \ along to the driver. It is common for a driver to control several devices;\
+        \ the minor number provides a way for the driver to differentiate among them."
       example: 1
       flat_name: process.tty.char_device.minor
       level: extended
@@ -17193,7 +17133,7 @@ source:
   type: group
 threat:
   description: "Fields to classify events and alerts according to a threat taxonomy\
-    \ such as the MITRE ATT&CK\xC2\xAE framework.\nThese fields are for users to classify\
+    \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
     \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
     \ The threat.tactic.* fields are meant to capture the high level category of the\
     \ threat (e.g. \"impact\"). The threat.technique.* fields are meant to capture\
@@ -18389,7 +18329,7 @@ threat:
     threat.enrichments.indicator.file.pe.product:
       dashed_name: threat-enrichments-indicator-file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: threat.enrichments.indicator.file.pe.product
       ignore_above: 1024
       level: extended
@@ -19887,7 +19827,7 @@ threat:
       dashed_name: threat-group-alias
       description: "The alias(es) of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       flat_name: threat.group.alias
       ignore_above: 1024
@@ -19901,7 +19841,7 @@ threat:
       dashed_name: threat-group-id
       description: "The id of the group for a set of related intrusion activity that\
         \ are tracked by a common name in the security community.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xC2\xAE group id."
+        \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       flat_name: threat.group.id
       ignore_above: 1024
@@ -19914,7 +19854,7 @@ threat:
       dashed_name: threat-group-name
       description: "The name of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE group name."
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       flat_name: threat.group.name
       ignore_above: 1024
@@ -19927,7 +19867,7 @@ threat:
       dashed_name: threat-group-reference
       description: "The reference URL of the group for a set of related intrusion\
         \ activity that are tracked by a common name in the security community.\n\
-        While not required, you can use a MITRE ATT&CK\xC2\xAE group reference URL."
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       flat_name: threat.group.reference
       ignore_above: 1024
@@ -21105,7 +21045,7 @@ threat:
     threat.indicator.file.pe.product:
       dashed_name: threat-indicator-file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
+      example: "Microsoft\xAE Windows\xAE Operating System"
       flat_name: threat.indicator.file.pe.product
       ignore_above: 1024
       level: extended
@@ -21695,10 +21635,10 @@ threat:
     threat.indicator.id:
       dashed_name: threat-indicator-id
       description: "The ID of the indicator used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple\
-        \ values to allow for the identification of the same indicator across systems\
-        \ that use different ID formats.\nWhile not required, a common approach is\
-        \ to use a STIX 2.x indicator ID."
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator ID."
       example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
       flat_name: threat.indicator.id
       ignore_above: 1024
@@ -22492,7 +22432,7 @@ threat:
       dashed_name: threat-software-alias
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xC2\xAE associated software description."
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
       example: '[ "X-Agent" ]'
       flat_name: threat.software.alias
       ignore_above: 1024
@@ -22505,8 +22445,8 @@ threat:
     threat.software.id:
       dashed_name: threat-software-id
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use a MITRE ATT&CK\xC2\xAE software id."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ a MITRE ATT&CK\xAE software id."
       example: S0552
       flat_name: threat.software.id
       ignore_above: 1024
@@ -22518,8 +22458,8 @@ threat:
     threat.software.name:
       dashed_name: threat-software-name
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use a MITRE ATT&CK\xC2\xAE software name."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       flat_name: threat.software.name
       ignore_above: 1024
@@ -22531,8 +22471,8 @@ threat:
     threat.software.platforms:
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
-        \ use MITRE ATT&CK\xC2\xAE software platform values."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
       expected_values:
       - AWS
@@ -22556,8 +22496,8 @@ threat:
     threat.software.reference:
       dashed_name: threat-software-reference
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xC2\xAE software reference URL."
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
+        \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       flat_name: threat.software.reference
       ignore_above: 1024
@@ -22569,8 +22509,8 @@ threat:
     threat.software.type:
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xC2\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
       expected_values:
       - Malware
@@ -22584,8 +22524,8 @@ threat:
       type: keyword
     threat.tactic.id:
       dashed_name: threat-tactic-id
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
-        \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0002
       flat_name: threat.tactic.id
       ignore_above: 1024
@@ -22598,7 +22538,7 @@ threat:
     threat.tactic.name:
       dashed_name: threat-tactic-name
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
       example: Execution
       flat_name: threat.tactic.name
       ignore_above: 1024
@@ -22611,7 +22551,7 @@ threat:
     threat.tactic.reference:
       dashed_name: threat-tactic-reference
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0002/
       flat_name: threat.tactic.reference
@@ -22624,8 +22564,8 @@ threat:
       type: keyword
     threat.technique.id:
       dashed_name: threat-technique-id
-      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
-        \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: T1059
       flat_name: threat.technique.id
       ignore_above: 1024
@@ -22638,7 +22578,7 @@ threat:
     threat.technique.name:
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: Command and Scripting Interpreter
       flat_name: threat.technique.name
       ignore_above: 1024
@@ -22655,7 +22595,7 @@ threat:
     threat.technique.reference:
       dashed_name: threat-technique-reference
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: https://attack.mitre.org/techniques/T1059/
       flat_name: threat.technique.reference
       ignore_above: 1024
@@ -22668,7 +22608,7 @@ threat:
     threat.technique.subtechnique.id:
       dashed_name: threat-technique-subtechnique-id
       description: "The full id of subtechnique used by this threat. You can use a\
-        \ MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: T1059.001
       flat_name: threat.technique.subtechnique.id
       ignore_above: 1024
@@ -22681,7 +22621,7 @@ threat:
     threat.technique.subtechnique.name:
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
-        \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
       flat_name: threat.technique.subtechnique.name
       ignore_above: 1024
@@ -22698,7 +22638,7 @@ threat:
     threat.technique.subtechnique.reference:
       dashed_name: threat-technique-subtechnique-reference
       description: "The reference url of subtechnique used by this threat. You can\
-        \ use a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       flat_name: threat.technique.subtechnique.reference
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2666,7 +2666,7 @@ dll:
     dll.pe.product:
       dashed_name: dll-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: dll.pe.product
       ignore_above: 1024
       level: extended
@@ -6156,7 +6156,7 @@ file:
     file.pe.product:
       dashed_name: file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: file.pe.product
       ignore_above: 1024
       level: extended
@@ -9758,7 +9758,7 @@ pe:
     pe.product:
       dashed_name: pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: pe.product
       ignore_above: 1024
       level: extended
@@ -10636,6 +10636,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10697,6 +10702,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11026,9 +11036,10 @@ process:
     process.entry_leader.tty.char_device.minor:
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       flat_name: process.entry_leader.tty.char_device.minor
       level: extended
@@ -11120,6 +11131,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11217,6 +11233,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11278,6 +11299,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -11489,9 +11515,10 @@ process:
     process.group_leader.tty.char_device.minor:
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       flat_name: process.group_leader.tty.char_device.minor
       level: extended
@@ -11971,6 +11998,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12633,6 +12665,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -13043,6 +13080,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -13260,7 +13302,7 @@ process:
     process.parent.pe.product:
       dashed_name: process-parent-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: process.parent.pe.product
       ignore_above: 1024
       level: extended
@@ -13597,9 +13639,10 @@ process:
     process.parent.tty.char_device.minor:
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       flat_name: process.parent.tty.char_device.minor
       level: extended
@@ -13888,7 +13931,7 @@ process:
     process.pe.product:
       dashed_name: process-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: process.pe.product
       ignore_above: 1024
       level: extended
@@ -14029,6 +14072,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.previous.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14214,6 +14262,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14275,6 +14328,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text
@@ -14604,9 +14662,10 @@ process:
     process.session_leader.tty.char_device.minor:
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       flat_name: process.session_leader.tty.char_device.minor
       level: extended
@@ -14800,9 +14859,10 @@ process:
     process.tty.char_device.minor:
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
-        \ number; other parts of the kernel don\u2019t use it, and merely pass it\
-        \ along to the driver. It is common for a driver to control several devices;\
-        \ the minor number provides a way for the driver to differentiate among them."
+        \ number; other parts of the kernel don\xE2\u20AC\u2122t use it, and merely\
+        \ pass it along to the driver. It is common for a driver to control several\
+        \ devices; the minor number provides a way for the driver to differentiate\
+        \ among them."
       example: 1
       flat_name: process.tty.char_device.minor
       level: extended
@@ -17133,7 +17193,7 @@ source:
   type: group
 threat:
   description: "Fields to classify events and alerts according to a threat taxonomy\
-    \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
+    \ such as the MITRE ATT&CK\xC2\xAE framework.\nThese fields are for users to classify\
     \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
     \ The threat.tactic.* fields are meant to capture the high level category of the\
     \ threat (e.g. \"impact\"). The threat.technique.* fields are meant to capture\
@@ -18329,7 +18389,7 @@ threat:
     threat.enrichments.indicator.file.pe.product:
       dashed_name: threat-enrichments-indicator-file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: threat.enrichments.indicator.file.pe.product
       ignore_above: 1024
       level: extended
@@ -19827,7 +19887,7 @@ threat:
       dashed_name: threat-group-alias
       description: "The alias(es) of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       flat_name: threat.group.alias
       ignore_above: 1024
@@ -19841,7 +19901,7 @@ threat:
       dashed_name: threat-group-id
       description: "The id of the group for a set of related intrusion activity that\
         \ are tracked by a common name in the security community.\nWhile not required,\
-        \ you can use a MITRE ATT&CK\xAE group id."
+        \ you can use a MITRE ATT&CK\xC2\xAE group id."
       example: G0037
       flat_name: threat.group.id
       ignore_above: 1024
@@ -19854,7 +19914,7 @@ threat:
       dashed_name: threat-group-name
       description: "The name of the group for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE group name."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE group name."
       example: FIN6
       flat_name: threat.group.name
       ignore_above: 1024
@@ -19867,7 +19927,7 @@ threat:
       dashed_name: threat-group-reference
       description: "The reference URL of the group for a set of related intrusion\
         \ activity that are tracked by a common name in the security community.\n\
-        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        While not required, you can use a MITRE ATT&CK\xC2\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       flat_name: threat.group.reference
       ignore_above: 1024
@@ -21045,7 +21105,7 @@ threat:
     threat.indicator.file.pe.product:
       dashed_name: threat-indicator-file-pe-product
       description: Internal product name of the file, provided at compile-time.
-      example: "Microsoft\xAE Windows\xAE Operating System"
+      example: "Microsoft\xC2\xAE Windows\xC2\xAE Operating System"
       flat_name: threat.indicator.file.pe.product
       ignore_above: 1024
       level: extended
@@ -21635,10 +21695,10 @@ threat:
     threat.indicator.id:
       dashed_name: threat-indicator-id
       description: "The ID of the indicator used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
-        \ to allow for the identification of the same indicator across systems that\
-        \ use different ID formats.\nWhile not required, a common approach is to use\
-        \ a STIX 2.x indicator ID."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE. This field can have multiple\
+        \ values to allow for the identification of the same indicator across systems\
+        \ that use different ID formats.\nWhile not required, a common approach is\
+        \ to use a STIX 2.x indicator ID."
       example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
       flat_name: threat.indicator.id
       ignore_above: 1024
@@ -22432,7 +22492,7 @@ threat:
       dashed_name: threat-software-alias
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
-        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+        \ required, you can use a MITRE ATT&CK\xC2\xAE associated software description."
       example: '[ "X-Agent" ]'
       flat_name: threat.software.alias
       ignore_above: 1024
@@ -22445,8 +22505,8 @@ threat:
     threat.software.id:
       dashed_name: threat-software-id
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ a MITRE ATT&CK\xAE software id."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use a MITRE ATT&CK\xC2\xAE software id."
       example: S0552
       flat_name: threat.software.id
       ignore_above: 1024
@@ -22458,8 +22518,8 @@ threat:
     threat.software.name:
       dashed_name: threat-software-name
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ a MITRE ATT&CK\xAE software name."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use a MITRE ATT&CK\xC2\xAE software name."
       example: AdFind
       flat_name: threat.software.name
       ignore_above: 1024
@@ -22471,8 +22531,8 @@ threat:
     threat.software.platforms:
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
-        \ MITRE ATT&CK\xAE software platform values."
+        \ commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can\
+        \ use MITRE ATT&CK\xC2\xAE software platform values."
       example: '[ "Windows" ]'
       expected_values:
       - AWS
@@ -22496,8 +22556,8 @@ threat:
     threat.software.reference:
       dashed_name: threat-software-reference
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
-        \ can use a MITRE ATT&CK\xAE software reference URL."
+        \ behavior commonly modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required,\
+        \ you can use a MITRE ATT&CK\xC2\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       flat_name: threat.software.reference
       ignore_above: 1024
@@ -22509,8 +22569,8 @@ threat:
     threat.software.type:
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xC2\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xC2\xAE software type."
       example: Tool
       expected_values:
       - Malware
@@ -22524,8 +22584,8 @@ threat:
       type: keyword
     threat.tactic.id:
       dashed_name: threat-tactic-id
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xC2\
+        \xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0002
       flat_name: threat.tactic.id
       ignore_above: 1024
@@ -22538,7 +22598,7 @@ threat:
     threat.tactic.name:
       dashed_name: threat-tactic-name
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
       example: Execution
       flat_name: threat.tactic.name
       ignore_above: 1024
@@ -22551,7 +22611,7 @@ threat:
     threat.tactic.reference:
       dashed_name: threat-tactic-reference
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
+        \ MITRE ATT&CK\xC2\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0002/
       flat_name: threat.tactic.reference
@@ -22564,8 +22624,8 @@ threat:
       type: keyword
     threat.technique.id:
       dashed_name: threat-technique-id
-      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xC2\
+        \xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: T1059
       flat_name: threat.technique.id
       ignore_above: 1024
@@ -22578,7 +22638,7 @@ threat:
     threat.technique.name:
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: Command and Scripting Interpreter
       flat_name: threat.technique.name
       ignore_above: 1024
@@ -22595,7 +22655,7 @@ threat:
     threat.technique.reference:
       dashed_name: threat-technique-reference
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+        \ a MITRE ATT&CK\xC2\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
       example: https://attack.mitre.org/techniques/T1059/
       flat_name: threat.technique.reference
       ignore_above: 1024
@@ -22608,7 +22668,7 @@ threat:
     threat.technique.subtechnique.id:
       dashed_name: threat-technique-subtechnique-id
       description: "The full id of subtechnique used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: T1059.001
       flat_name: threat.technique.subtechnique.id
       ignore_above: 1024
@@ -22621,7 +22681,7 @@ threat:
     threat.technique.subtechnique.name:
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
       flat_name: threat.technique.subtechnique.name
       ignore_above: 1024
@@ -22638,7 +22698,7 @@ threat:
     threat.technique.subtechnique.reference:
       dashed_name: threat-technique-subtechnique-reference
       description: "The reference url of subtechnique used by this threat. You can\
-        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+        \ use a MITRE ATT&CK\xC2\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       flat_name: threat.technique.subtechnique.reference
       ignore_above: 1024

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -275,11 +275,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -304,11 +299,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -481,11 +471,6 @@
             },
             "executable": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -519,11 +504,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -548,11 +528,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -812,11 +787,6 @@
             },
             "name": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -1032,11 +1002,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1171,11 +1136,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1532,11 +1492,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1627,11 +1582,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1656,11 +1606,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -275,6 +275,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -299,6 +304,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -471,6 +481,11 @@
             },
             "executable": {
               "fields": {
+                "caseless": {
+                  "ignore_above": 1024,
+                  "normalizer": "lowercase",
+                  "type": "keyword"
+                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -504,6 +519,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -528,6 +548,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -787,6 +812,11 @@
             },
             "name": {
               "fields": {
+                "caseless": {
+                  "ignore_above": 1024,
+                  "normalizer": "lowercase",
+                  "type": "keyword"
+                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -1002,6 +1032,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1136,6 +1171,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1492,6 +1532,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1582,6 +1627,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1606,6 +1656,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2996,11 +2996,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3025,11 +3020,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3202,11 +3192,6 @@
           },
           "executable": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3240,11 +3225,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3269,11 +3249,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3533,11 +3508,6 @@
           },
           "name": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3753,11 +3723,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3892,11 +3857,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4253,11 +4213,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4348,11 +4303,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4377,11 +4327,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2996,6 +2996,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3020,6 +3025,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3192,6 +3202,11 @@
           },
           "executable": {
             "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3225,6 +3240,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3249,6 +3269,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3508,6 +3533,11 @@
           },
           "name": {
             "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3723,6 +3753,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3857,6 +3892,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4213,6 +4253,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4303,6 +4348,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4327,6 +4377,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5125,6 +5125,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5163,6 +5167,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5432,6 +5440,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5498,6 +5511,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5536,6 +5553,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5950,6 +5971,11 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
+        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6339,6 +6365,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6582,6 +6612,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7168,6 +7202,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7283,6 +7321,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7321,6 +7363,10 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
+      - name: caseless
+        type: keyword
+        normalizer: lowercase
+        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -641,11 +641,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 8.12.0-dev,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
 8.12.0-dev,true,process,process.entry_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.entry_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.entry_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.entry_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.entry_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.entry_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.entry_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev,true,process,process.entry_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.entry_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.entry_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.entry_leader.parent.pid,long,core,,4242,Process id.
@@ -681,6 +683,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.12.0-dev,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.12.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -689,11 +692,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.group_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.group_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.group_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.group_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.group_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.group_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev,true,process,process.group_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.group_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.group_leader.pid,long,core,,4242,Process id.
 8.12.0-dev,true,process,process.group_leader.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -753,6 +758,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
+8.12.0-dev,true,process,process.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -808,6 +814,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.parent.end,date,extended,,2016-05-23T08:05:34.853Z,The time the process ended.
 8.12.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.parent.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev,true,process,process.parent.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -841,6 +848,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
+8.12.0-dev,true,process,process.parent.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.12.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -924,6 +932,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.previous.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.previous.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.real_group.name,keyword,extended,,,Name of the group.
@@ -941,11 +950,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.session_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.12.0-dev,true,process,process.session_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.session_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.session_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.session_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.session_leader.name,keyword,extended,,ssh,Process name.
+8.12.0-dev,true,process,process.session_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.session_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.session_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.session_leader.parent.pid,long,core,,4242,Process id.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8357,6 +8357,11 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8418,6 +8423,11 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.entry_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8841,6 +8851,11 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -8938,6 +8953,11 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -8999,6 +9019,11 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.group_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9688,6 +9713,11 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10349,6 +10379,11 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10758,6 +10793,11 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.parent.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11742,6 +11782,11 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.previous.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -11927,6 +11972,11 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.executable.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -11988,6 +12038,11 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
+  - flat_name: process.session_leader.name.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10556,6 +10556,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10617,6 +10622,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.entry_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11040,6 +11050,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11137,6 +11152,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11198,6 +11218,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.group_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -11891,6 +11916,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12553,6 +12583,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -12963,6 +12998,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.parent.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -13949,6 +13989,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.previous.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14134,6 +14179,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.executable.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14195,6 +14245,11 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
+      - flat_name: process.session_leader.name.caseless
+        ignore_above: 1024
+        name: caseless
+        normalizer: lowercase
+        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -275,6 +275,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -299,6 +304,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -471,6 +481,11 @@
             },
             "executable": {
               "fields": {
+                "caseless": {
+                  "ignore_above": 1024,
+                  "normalizer": "lowercase",
+                  "type": "keyword"
+                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -504,6 +519,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -528,6 +548,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -787,6 +812,11 @@
             },
             "name": {
               "fields": {
+                "caseless": {
+                  "ignore_above": 1024,
+                  "normalizer": "lowercase",
+                  "type": "keyword"
+                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -1002,6 +1032,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1136,6 +1171,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1492,6 +1532,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1582,6 +1627,11 @@
                 },
                 "executable": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1606,6 +1656,11 @@
                 },
                 "name": {
                   "fields": {
+                    "caseless": {
+                      "ignore_above": 1024,
+                      "normalizer": "lowercase",
+                      "type": "keyword"
+                    },
                     "text": {
                       "type": "match_only_text"
                     }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2954,6 +2954,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -2978,6 +2983,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3150,6 +3160,11 @@
           },
           "executable": {
             "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3183,6 +3198,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3207,6 +3227,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3466,6 +3491,11 @@
           },
           "name": {
             "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3681,6 +3711,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3815,6 +3850,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4171,6 +4211,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4261,6 +4306,11 @@
               },
               "executable": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4285,6 +4335,11 @@
               },
               "name": {
                 "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
                   "text": {
                     "type": "match_only_text"
                   }

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -112,6 +112,10 @@
         Sometimes called program name or similar.
       example: ssh
       multi_fields:
+        - name: caseless
+          ignore_above: 1024
+          normalizer: lowercase
+          type: keyword
         - type: match_only_text
           name: text
 
@@ -171,6 +175,10 @@
         Absolute path to the process executable.
       example: /usr/bin/ssh
       multi_fields:
+        - name: caseless
+          ignore_above: 1024
+          normalizer: lowercase
+          type: keyword
         - type: match_only_text
           name: text
 


### PR DESCRIPTION
## Summary

Related PR: https://github.com/elastic/integrations/pull/9850

This PR aims to add a subfield to the `process.name` and `process.executable` fields to improve the compatibility of data sources like System, Sysmon, etc., with our Elastic Defend data. This enables us to handle language limitations in KQL more effectively.

Elastic Defend Mapping:
![image](https://github.com/elastic/integrations/assets/26856693/a4fd28f6-c0ac-41bc-bf6a-84ee8be503c2)