### PR TITLE
Add new fields file.origin_referrer_url & file.origin_url

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -22,7 +22,9 @@ Thanks, you're awesome :-) -->
 * Advanced `process.io` and `process.tty` fields to GA. #2317
 * Added `threat.indicator.id`. #2324
 * Added `process.group` to generated schemas. #2335
+* Added `file.origin_referrer_url` and `file.origin_url` #2348
 
+* 
 #### Improvements
 
 #### Deprecated

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,7 +24,6 @@ Thanks, you're awesome :-) -->
 * Added `process.group` to generated schemas. #2335
 * Added `file.origin_referrer_url` and `file.origin_url` #2348
 
-* 
 #### Improvements
 
 #### Deprecated

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -4302,7 +4302,7 @@ example: `example.png`
 [[field-file-origin-referrer-url]]
 <<field-file-origin-referrer-url, file.origin_referrer_url>>
 
-a| The url of the webpage that linked to the file.
+a| The URL of the webpage that linked to the file.
 
 type: keyword
 
@@ -4318,7 +4318,7 @@ example: `https://example.com`
 [[field-file-origin-url]]
 <<field-file-origin-url, file.origin_url>>
 
-a| The url where the file is hosted.
+a| The URL where the file is hosted.
 
 type: keyword
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -4299,6 +4299,38 @@ example: `example.png`
 // ===============================================================
 
 |
+[[field-file-origin-referrer-url]]
+<<field-file-origin-referrer-url, file.origin_referrer_url>>
+
+a| The url of the webpage that linked to the file.
+
+type: keyword
+
+
+
+example: `https://example.com`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-file-origin-url]]
+<<field-file-origin-url, file.origin_url>>
+
+a| The url where the file is hosted.
+
+type: keyword
+
+
+
+example: `https://example.com/file.zip`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-file-owner]]
 <<field-file-owner, file.owner>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2976,14 +2976,14 @@
     - name: origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
@@ -9586,14 +9586,14 @@
     - name: enrichments.indicator.file.origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: enrichments.indicator.file.origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
@@ -11207,14 +11207,14 @@
     - name: indicator.file.origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: indicator.file.origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2977,14 +2977,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: owner
@@ -9587,14 +9587,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: enrichments.indicator.file.origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: enrichments.indicator.file.owner
@@ -11208,14 +11208,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: indicator.file.origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: indicator.file.owner

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2973,6 +2973,20 @@
       ignore_above: 1024
       description: Name of the file including the extension, without the directory.
       example: example.png
+    - name: origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      default_field: false
     - name: owner
       level: extended
       type: keyword
@@ -9569,6 +9583,20 @@
       description: Name of the file including the extension, without the directory.
       example: example.png
       default_field: false
+    - name: enrichments.indicator.file.origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: enrichments.indicator.file.origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      default_field: false
     - name: enrichments.indicator.file.owner
       level: extended
       type: keyword
@@ -11175,6 +11203,20 @@
       ignore_above: 1024
       description: Name of the file including the extension, without the directory.
       example: example.png
+      default_field: false
+    - name: indicator.file.origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: indicator.file.origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
       default_field: false
     - name: indicator.file.owner
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -358,8 +358,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev+exp,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev+exp,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev+exp,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev+exp,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev+exp,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1220,8 +1220,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1439,8 +1439,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,threat,threat.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev+exp,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev+exp,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev+exp,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev+exp,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev+exp,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -358,6 +358,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev+exp,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev+exp,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev+exp,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1218,6 +1220,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1435,6 +1439,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev+exp,true,threat,threat.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev+exp,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev+exp,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev+exp,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev+exp,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev+exp,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev+exp,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4887,25 +4887,25 @@ file.name:
   type: keyword
 file.origin_referrer_url:
   dashed_name: file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: file.origin_referrer_url
   ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 file.origin_url:
   dashed_name: file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: file.origin_url
   ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 file.owner:
   dashed_name: file-owner
@@ -15472,7 +15472,7 @@ threat.enrichments.indicator.file.name:
   type: keyword
 threat.enrichments.indicator.file.origin_referrer_url:
   dashed_name: threat-enrichments-indicator-file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.enrichments.indicator.file.origin_referrer_url
   ignore_above: 8192
@@ -15480,11 +15480,11 @@ threat.enrichments.indicator.file.origin_referrer_url:
   name: origin_referrer_url
   normalize: []
   original_fieldset: file
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 threat.enrichments.indicator.file.origin_url:
   dashed_name: threat-enrichments-indicator-file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.enrichments.indicator.file.origin_url
   ignore_above: 8192
@@ -15492,7 +15492,7 @@ threat.enrichments.indicator.file.origin_url:
   name: origin_url
   normalize: []
   original_fieldset: file
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 threat.enrichments.indicator.file.owner:
   dashed_name: threat-enrichments-indicator-file-owner
@@ -18206,7 +18206,7 @@ threat.indicator.file.name:
   type: keyword
 threat.indicator.file.origin_referrer_url:
   dashed_name: threat-indicator-file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.indicator.file.origin_referrer_url
   ignore_above: 8192
@@ -18214,11 +18214,11 @@ threat.indicator.file.origin_referrer_url:
   name: origin_referrer_url
   normalize: []
   original_fieldset: file
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 threat.indicator.file.origin_url:
   dashed_name: threat-indicator-file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.indicator.file.origin_url
   ignore_above: 8192
@@ -18226,7 +18226,7 @@ threat.indicator.file.origin_url:
   name: origin_url
   normalize: []
   original_fieldset: file
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 threat.indicator.file.owner:
   dashed_name: threat-indicator-file-owner

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4885,6 +4885,28 @@ file.name:
   normalize: []
   short: Name of the file including the extension, without the directory.
   type: keyword
+file.origin_referrer_url:
+  dashed_name: file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  short: The url of the webpage that linked to the file.
+  type: keyword
+file.origin_url:
+  dashed_name: file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  short: The url where the file is hosted.
+  type: keyword
 file.owner:
   dashed_name: file-owner
   description: File owner's username.
@@ -15448,6 +15470,30 @@ threat.enrichments.indicator.file.name:
   original_fieldset: file
   short: Name of the file including the extension, without the directory.
   type: keyword
+threat.enrichments.indicator.file.origin_referrer_url:
+  dashed_name: threat-enrichments-indicator-file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: threat.enrichments.indicator.file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  original_fieldset: file
+  short: The url of the webpage that linked to the file.
+  type: keyword
+threat.enrichments.indicator.file.origin_url:
+  dashed_name: threat-enrichments-indicator-file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: threat.enrichments.indicator.file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  original_fieldset: file
+  short: The url where the file is hosted.
+  type: keyword
 threat.enrichments.indicator.file.owner:
   dashed_name: threat-enrichments-indicator-file-owner
   description: File owner's username.
@@ -18157,6 +18203,30 @@ threat.indicator.file.name:
   normalize: []
   original_fieldset: file
   short: Name of the file including the extension, without the directory.
+  type: keyword
+threat.indicator.file.origin_referrer_url:
+  dashed_name: threat-indicator-file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: threat.indicator.file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  original_fieldset: file
+  short: The url of the webpage that linked to the file.
+  type: keyword
+threat.indicator.file.origin_url:
+  dashed_name: threat-indicator-file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: threat.indicator.file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  original_fieldset: file
+  short: The url where the file is hosted.
   type: keyword
 threat.indicator.file.owner:
   dashed_name: threat-indicator-file-owner

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4890,7 +4890,7 @@ file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -4901,7 +4901,7 @@ file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
@@ -15475,7 +15475,7 @@ threat.enrichments.indicator.file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.enrichments.indicator.file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -15487,7 +15487,7 @@ threat.enrichments.indicator.file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.enrichments.indicator.file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
@@ -18209,7 +18209,7 @@ threat.indicator.file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.indicator.file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -18221,7 +18221,7 @@ threat.indicator.file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.indicator.file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5922,25 +5922,25 @@ file:
       type: keyword
     file.origin_referrer_url:
       dashed_name: file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: file.origin_referrer_url
       ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     file.origin_url:
       dashed_name: file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: file.origin_url
       ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     file.owner:
       dashed_name: file-owner
@@ -18137,7 +18137,7 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.origin_referrer_url:
       dashed_name: threat-enrichments-indicator-file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.enrichments.indicator.file.origin_referrer_url
       ignore_above: 8192
@@ -18145,11 +18145,11 @@ threat:
       name: origin_referrer_url
       normalize: []
       original_fieldset: file
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     threat.enrichments.indicator.file.origin_url:
       dashed_name: threat-enrichments-indicator-file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.enrichments.indicator.file.origin_url
       ignore_above: 8192
@@ -18157,7 +18157,7 @@ threat:
       name: origin_url
       normalize: []
       original_fieldset: file
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     threat.enrichments.indicator.file.owner:
       dashed_name: threat-enrichments-indicator-file-owner
@@ -20877,7 +20877,7 @@ threat:
       type: keyword
     threat.indicator.file.origin_referrer_url:
       dashed_name: threat-indicator-file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.indicator.file.origin_referrer_url
       ignore_above: 8192
@@ -20885,11 +20885,11 @@ threat:
       name: origin_referrer_url
       normalize: []
       original_fieldset: file
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     threat.indicator.file.origin_url:
       dashed_name: threat-indicator-file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.indicator.file.origin_url
       ignore_above: 8192
@@ -20897,7 +20897,7 @@ threat:
       name: origin_url
       normalize: []
       original_fieldset: file
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     threat.indicator.file.owner:
       dashed_name: threat-indicator-file-owner

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5925,7 +5925,7 @@ file:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -5936,7 +5936,7 @@ file:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
@@ -18140,7 +18140,7 @@ threat:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.enrichments.indicator.file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -18152,7 +18152,7 @@ threat:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.enrichments.indicator.file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
@@ -20880,7 +20880,7 @@ threat:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.indicator.file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -20892,7 +20892,7 @@ threat:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.indicator.file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5920,6 +5920,28 @@ file:
       normalize: []
       short: Name of the file including the extension, without the directory.
       type: keyword
+    file.origin_referrer_url:
+      dashed_name: file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    file.origin_url:
+      dashed_name: file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      short: The url where the file is hosted.
+      type: keyword
     file.owner:
       dashed_name: file-owner
       description: File owner's username.
@@ -18113,6 +18135,30 @@ threat:
       original_fieldset: file
       short: Name of the file including the extension, without the directory.
       type: keyword
+    threat.enrichments.indicator.file.origin_referrer_url:
+      dashed_name: threat-enrichments-indicator-file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: threat.enrichments.indicator.file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      original_fieldset: file
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    threat.enrichments.indicator.file.origin_url:
+      dashed_name: threat-enrichments-indicator-file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: threat.enrichments.indicator.file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      original_fieldset: file
+      short: The url where the file is hosted.
+      type: keyword
     threat.enrichments.indicator.file.owner:
       dashed_name: threat-enrichments-indicator-file-owner
       description: File owner's username.
@@ -20828,6 +20874,30 @@ threat:
       normalize: []
       original_fieldset: file
       short: Name of the file including the extension, without the directory.
+      type: keyword
+    threat.indicator.file.origin_referrer_url:
+      dashed_name: threat-indicator-file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: threat.indicator.file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      original_fieldset: file
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    threat.indicator.file.origin_url:
+      dashed_name: threat-indicator-file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: threat.indicator.file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      original_fieldset: file
+      short: The url where the file is hosted.
       type: keyword
     threat.indicator.file.owner:
       dashed_name: threat-indicator-file-owner

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -340,6 +340,14 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "origin_referrer_url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origin_url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "owner": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -341,11 +341,11 @@
               "type": "keyword"
             },
             "origin_referrer_url": {
-              "ignore_above": 1024,
+              "ignore_above": 8192,
               "type": "keyword"
             },
             "origin_url": {
-              "ignore_above": 1024,
+              "ignore_above": 8192,
               "type": "keyword"
             },
             "owner": {

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -325,11 +325,11 @@
                           "type": "keyword"
                         },
                         "origin_referrer_url": {
-                          "ignore_above": 1024,
+                          "ignore_above": 8192,
                           "type": "keyword"
                         },
                         "origin_url": {
-                          "ignore_above": 1024,
+                          "ignore_above": 8192,
                           "type": "keyword"
                         },
                         "owner": {
@@ -1254,11 +1254,11 @@
                       "type": "keyword"
                     },
                     "origin_referrer_url": {
-                      "ignore_above": 1024,
+                      "ignore_above": 8192,
                       "type": "keyword"
                     },
                     "origin_url": {
-                      "ignore_above": 1024,
+                      "ignore_above": 8192,
                       "type": "keyword"
                     },
                     "owner": {

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -324,6 +324,14 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "origin_referrer_url": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "origin_url": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "owner": {
                           "ignore_above": 1024,
                           "type": "keyword"
@@ -1242,6 +1250,14 @@
                       "type": "date"
                     },
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "origin_referrer_url": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "origin_url": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1677,11 +1677,11 @@
             "type": "keyword"
           },
           "origin_referrer_url": {
-            "ignore_above": 1024,
+            "ignore_above": 8192,
             "type": "keyword"
           },
           "origin_url": {
-            "ignore_above": 1024,
+            "ignore_above": 8192,
             "type": "keyword"
           },
           "owner": {
@@ -5550,11 +5550,11 @@
                         "type": "keyword"
                       },
                       "origin_referrer_url": {
-                        "ignore_above": 1024,
+                        "ignore_above": 8192,
                         "type": "keyword"
                       },
                       "origin_url": {
-                        "ignore_above": 1024,
+                        "ignore_above": 8192,
                         "type": "keyword"
                       },
                       "owner": {
@@ -6479,11 +6479,11 @@
                     "type": "keyword"
                   },
                   "origin_referrer_url": {
-                    "ignore_above": 1024,
+                    "ignore_above": 8192,
                     "type": "keyword"
                   },
                   "origin_url": {
-                    "ignore_above": 1024,
+                    "ignore_above": 8192,
                     "type": "keyword"
                   },
                   "owner": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1676,6 +1676,14 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "origin_referrer_url": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "origin_url": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "owner": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -5541,6 +5549,14 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "origin_referrer_url": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "origin_url": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "owner": {
                         "ignore_above": 1024,
                         "type": "keyword"
@@ -6459,6 +6475,14 @@
                     "type": "date"
                   },
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "origin_referrer_url": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "origin_url": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2927,14 +2927,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: owner
@@ -9537,14 +9537,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: enrichments.indicator.file.origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: enrichments.indicator.file.owner
@@ -11158,14 +11158,14 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: indicator.file.origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
     - name: indicator.file.owner

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2923,6 +2923,20 @@
       ignore_above: 1024
       description: Name of the file including the extension, without the directory.
       example: example.png
+    - name: origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      default_field: false
     - name: owner
       level: extended
       type: keyword
@@ -9519,6 +9533,20 @@
       description: Name of the file including the extension, without the directory.
       example: example.png
       default_field: false
+    - name: enrichments.indicator.file.origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: enrichments.indicator.file.origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      default_field: false
     - name: enrichments.indicator.file.owner
       level: extended
       type: keyword
@@ -11125,6 +11153,20 @@
       ignore_above: 1024
       description: Name of the file including the extension, without the directory.
       example: example.png
+      default_field: false
+    - name: indicator.file.origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: indicator.file.origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
       default_field: false
     - name: indicator.file.owner
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2926,14 +2926,14 @@
     - name: origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
@@ -9536,14 +9536,14 @@
     - name: enrichments.indicator.file.origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: enrichments.indicator.file.origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false
@@ -11157,14 +11157,14 @@
     - name: indicator.file.origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
       default_field: false
     - name: indicator.file.origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       default_field: false

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -351,6 +351,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1211,6 +1213,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1428,6 +1432,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,threat,threat.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+8.12.0-dev,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
+8.12.0-dev,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
 8.12.0-dev,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -351,8 +351,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev,true,file,file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev,true,file,file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1213,8 +1213,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev,true,threat,threat.enrichments.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
@@ -1432,8 +1432,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.12.0-dev,true,threat,threat.indicator.file.mtime,date,extended,,,Last time the file content was modified.
 8.12.0-dev,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
-8.12.0-dev,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The url of the webpage that linked to the file.
-8.12.0-dev,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The url where the file is hosted.
+8.12.0-dev,true,threat,threat.indicator.file.origin_referrer_url,keyword,extended,,https://example.com,The URL of the webpage that linked to the file.
+8.12.0-dev,true,threat,threat.indicator.file.origin_url,keyword,extended,,https://example.com/file.zip,The URL where the file is hosted.
 8.12.0-dev,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.12.0-dev,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.12.0-dev,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4821,7 +4821,7 @@ file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -4832,7 +4832,7 @@ file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
@@ -15406,7 +15406,7 @@ threat.enrichments.indicator.file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.enrichments.indicator.file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -15418,7 +15418,7 @@ threat.enrichments.indicator.file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.enrichments.indicator.file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
@@ -18140,7 +18140,7 @@ threat.indicator.file.origin_referrer_url:
   description: The url of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.indicator.file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -18152,7 +18152,7 @@ threat.indicator.file.origin_url:
   description: The url where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.indicator.file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4818,25 +4818,25 @@ file.name:
   type: keyword
 file.origin_referrer_url:
   dashed_name: file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: file.origin_referrer_url
   ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 file.origin_url:
   dashed_name: file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: file.origin_url
   ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 file.owner:
   dashed_name: file-owner
@@ -15403,7 +15403,7 @@ threat.enrichments.indicator.file.name:
   type: keyword
 threat.enrichments.indicator.file.origin_referrer_url:
   dashed_name: threat-enrichments-indicator-file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.enrichments.indicator.file.origin_referrer_url
   ignore_above: 8192
@@ -15411,11 +15411,11 @@ threat.enrichments.indicator.file.origin_referrer_url:
   name: origin_referrer_url
   normalize: []
   original_fieldset: file
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 threat.enrichments.indicator.file.origin_url:
   dashed_name: threat-enrichments-indicator-file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.enrichments.indicator.file.origin_url
   ignore_above: 8192
@@ -15423,7 +15423,7 @@ threat.enrichments.indicator.file.origin_url:
   name: origin_url
   normalize: []
   original_fieldset: file
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 threat.enrichments.indicator.file.owner:
   dashed_name: threat-enrichments-indicator-file-owner
@@ -18137,7 +18137,7 @@ threat.indicator.file.name:
   type: keyword
 threat.indicator.file.origin_referrer_url:
   dashed_name: threat-indicator-file-origin-referrer-url
-  description: The url of the webpage that linked to the file.
+  description: The URL of the webpage that linked to the file.
   example: https://example.com
   flat_name: threat.indicator.file.origin_referrer_url
   ignore_above: 8192
@@ -18145,11 +18145,11 @@ threat.indicator.file.origin_referrer_url:
   name: origin_referrer_url
   normalize: []
   original_fieldset: file
-  short: The url of the webpage that linked to the file.
+  short: The URL of the webpage that linked to the file.
   type: keyword
 threat.indicator.file.origin_url:
   dashed_name: threat-indicator-file-origin-url
-  description: The url where the file is hosted.
+  description: The URL where the file is hosted.
   example: https://example.com/file.zip
   flat_name: threat.indicator.file.origin_url
   ignore_above: 8192
@@ -18157,7 +18157,7 @@ threat.indicator.file.origin_url:
   name: origin_url
   normalize: []
   original_fieldset: file
-  short: The url where the file is hosted.
+  short: The URL where the file is hosted.
   type: keyword
 threat.indicator.file.owner:
   dashed_name: threat-indicator-file-owner

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4816,6 +4816,28 @@ file.name:
   normalize: []
   short: Name of the file including the extension, without the directory.
   type: keyword
+file.origin_referrer_url:
+  dashed_name: file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  short: The url of the webpage that linked to the file.
+  type: keyword
+file.origin_url:
+  dashed_name: file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  short: The url where the file is hosted.
+  type: keyword
 file.owner:
   dashed_name: file-owner
   description: File owner's username.
@@ -15379,6 +15401,30 @@ threat.enrichments.indicator.file.name:
   original_fieldset: file
   short: Name of the file including the extension, without the directory.
   type: keyword
+threat.enrichments.indicator.file.origin_referrer_url:
+  dashed_name: threat-enrichments-indicator-file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: threat.enrichments.indicator.file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  original_fieldset: file
+  short: The url of the webpage that linked to the file.
+  type: keyword
+threat.enrichments.indicator.file.origin_url:
+  dashed_name: threat-enrichments-indicator-file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: threat.enrichments.indicator.file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  original_fieldset: file
+  short: The url where the file is hosted.
+  type: keyword
 threat.enrichments.indicator.file.owner:
   dashed_name: threat-enrichments-indicator-file-owner
   description: File owner's username.
@@ -18088,6 +18134,30 @@ threat.indicator.file.name:
   normalize: []
   original_fieldset: file
   short: Name of the file including the extension, without the directory.
+  type: keyword
+threat.indicator.file.origin_referrer_url:
+  dashed_name: threat-indicator-file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  example: https://example.com
+  flat_name: threat.indicator.file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  original_fieldset: file
+  short: The url of the webpage that linked to the file.
+  type: keyword
+threat.indicator.file.origin_url:
+  dashed_name: threat-indicator-file-origin-url
+  description: The url where the file is hosted.
+  example: https://example.com/file.zip
+  flat_name: threat.indicator.file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  original_fieldset: file
+  short: The url where the file is hosted.
   type: keyword
 threat.indicator.file.owner:
   dashed_name: threat-indicator-file-owner

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5842,25 +5842,25 @@ file:
       type: keyword
     file.origin_referrer_url:
       dashed_name: file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: file.origin_referrer_url
       ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     file.origin_url:
       dashed_name: file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: file.origin_url
       ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     file.owner:
       dashed_name: file-owner
@@ -18057,7 +18057,7 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.origin_referrer_url:
       dashed_name: threat-enrichments-indicator-file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.enrichments.indicator.file.origin_referrer_url
       ignore_above: 8192
@@ -18065,11 +18065,11 @@ threat:
       name: origin_referrer_url
       normalize: []
       original_fieldset: file
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     threat.enrichments.indicator.file.origin_url:
       dashed_name: threat-enrichments-indicator-file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.enrichments.indicator.file.origin_url
       ignore_above: 8192
@@ -18077,7 +18077,7 @@ threat:
       name: origin_url
       normalize: []
       original_fieldset: file
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     threat.enrichments.indicator.file.owner:
       dashed_name: threat-enrichments-indicator-file-owner
@@ -20797,7 +20797,7 @@ threat:
       type: keyword
     threat.indicator.file.origin_referrer_url:
       dashed_name: threat-indicator-file-origin-referrer-url
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.indicator.file.origin_referrer_url
       ignore_above: 8192
@@ -20805,11 +20805,11 @@ threat:
       name: origin_referrer_url
       normalize: []
       original_fieldset: file
-      short: The url of the webpage that linked to the file.
+      short: The URL of the webpage that linked to the file.
       type: keyword
     threat.indicator.file.origin_url:
       dashed_name: threat-indicator-file-origin-url
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.indicator.file.origin_url
       ignore_above: 8192
@@ -20817,7 +20817,7 @@ threat:
       name: origin_url
       normalize: []
       original_fieldset: file
-      short: The url where the file is hosted.
+      short: The URL where the file is hosted.
       type: keyword
     threat.indicator.file.owner:
       dashed_name: threat-indicator-file-owner

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5845,7 +5845,7 @@ file:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -5856,7 +5856,7 @@ file:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
@@ -18060,7 +18060,7 @@ threat:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.enrichments.indicator.file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -18072,7 +18072,7 @@ threat:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.enrichments.indicator.file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []
@@ -20800,7 +20800,7 @@ threat:
       description: The url of the webpage that linked to the file.
       example: https://example.com
       flat_name: threat.indicator.file.origin_referrer_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_referrer_url
       normalize: []
@@ -20812,7 +20812,7 @@ threat:
       description: The url where the file is hosted.
       example: https://example.com/file.zip
       flat_name: threat.indicator.file.origin_url
-      ignore_above: 1024
+      ignore_above: 8192
       level: extended
       name: origin_url
       normalize: []

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5840,6 +5840,28 @@ file:
       normalize: []
       short: Name of the file including the extension, without the directory.
       type: keyword
+    file.origin_referrer_url:
+      dashed_name: file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    file.origin_url:
+      dashed_name: file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      short: The url where the file is hosted.
+      type: keyword
     file.owner:
       dashed_name: file-owner
       description: File owner's username.
@@ -18033,6 +18055,30 @@ threat:
       original_fieldset: file
       short: Name of the file including the extension, without the directory.
       type: keyword
+    threat.enrichments.indicator.file.origin_referrer_url:
+      dashed_name: threat-enrichments-indicator-file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: threat.enrichments.indicator.file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      original_fieldset: file
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    threat.enrichments.indicator.file.origin_url:
+      dashed_name: threat-enrichments-indicator-file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: threat.enrichments.indicator.file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      original_fieldset: file
+      short: The url where the file is hosted.
+      type: keyword
     threat.enrichments.indicator.file.owner:
       dashed_name: threat-enrichments-indicator-file-owner
       description: File owner's username.
@@ -20748,6 +20794,30 @@ threat:
       normalize: []
       original_fieldset: file
       short: Name of the file including the extension, without the directory.
+      type: keyword
+    threat.indicator.file.origin_referrer_url:
+      dashed_name: threat-indicator-file-origin-referrer-url
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      flat_name: threat.indicator.file.origin_referrer_url
+      ignore_above: 1024
+      level: extended
+      name: origin_referrer_url
+      normalize: []
+      original_fieldset: file
+      short: The url of the webpage that linked to the file.
+      type: keyword
+    threat.indicator.file.origin_url:
+      dashed_name: threat-indicator-file-origin-url
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      flat_name: threat.indicator.file.origin_url
+      ignore_above: 1024
+      level: extended
+      name: origin_url
+      normalize: []
+      original_fieldset: file
+      short: The url where the file is hosted.
       type: keyword
     threat.indicator.file.owner:
       dashed_name: threat-indicator-file-owner

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -340,6 +340,14 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "origin_referrer_url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origin_url": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "owner": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -341,11 +341,11 @@
               "type": "keyword"
             },
             "origin_referrer_url": {
-              "ignore_above": 1024,
+              "ignore_above": 8192,
               "type": "keyword"
             },
             "origin_url": {
-              "ignore_above": 1024,
+              "ignore_above": 8192,
               "type": "keyword"
             },
             "owner": {

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -325,11 +325,11 @@
                           "type": "keyword"
                         },
                         "origin_referrer_url": {
-                          "ignore_above": 1024,
+                          "ignore_above": 8192,
                           "type": "keyword"
                         },
                         "origin_url": {
-                          "ignore_above": 1024,
+                          "ignore_above": 8192,
                           "type": "keyword"
                         },
                         "owner": {
@@ -1254,11 +1254,11 @@
                       "type": "keyword"
                     },
                     "origin_referrer_url": {
-                      "ignore_above": 1024,
+                      "ignore_above": 8192,
                       "type": "keyword"
                     },
                     "origin_url": {
-                      "ignore_above": 1024,
+                      "ignore_above": 8192,
                       "type": "keyword"
                     },
                     "owner": {

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -324,6 +324,14 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "origin_referrer_url": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "origin_url": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "owner": {
                           "ignore_above": 1024,
                           "type": "keyword"
@@ -1242,6 +1250,14 @@
                       "type": "date"
                     },
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "origin_referrer_url": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "origin_url": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1635,11 +1635,11 @@
             "type": "keyword"
           },
           "origin_referrer_url": {
-            "ignore_above": 1024,
+            "ignore_above": 8192,
             "type": "keyword"
           },
           "origin_url": {
-            "ignore_above": 1024,
+            "ignore_above": 8192,
             "type": "keyword"
           },
           "owner": {
@@ -5508,11 +5508,11 @@
                         "type": "keyword"
                       },
                       "origin_referrer_url": {
-                        "ignore_above": 1024,
+                        "ignore_above": 8192,
                         "type": "keyword"
                       },
                       "origin_url": {
-                        "ignore_above": 1024,
+                        "ignore_above": 8192,
                         "type": "keyword"
                       },
                       "owner": {
@@ -6437,11 +6437,11 @@
                     "type": "keyword"
                   },
                   "origin_referrer_url": {
-                    "ignore_above": 1024,
+                    "ignore_above": 8192,
                     "type": "keyword"
                   },
                   "origin_url": {
-                    "ignore_above": 1024,
+                    "ignore_above": 8192,
                     "type": "keyword"
                   },
                   "owner": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1634,6 +1634,14 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "origin_referrer_url": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "origin_url": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "owner": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -5499,6 +5507,14 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "origin_referrer_url": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "origin_url": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "owner": {
                         "ignore_above": 1024,
                         "type": "keyword"
@@ -6417,6 +6433,14 @@
                     "type": "date"
                   },
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "origin_referrer_url": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "origin_url": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -225,3 +225,15 @@
 
       short: A fork is additional data associated with a filesystem object.
       example: Zone.Identifer
+
+    - name: origin_referrer_url
+      level: extended
+      type: keyword
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+
+    - name: origin_url
+      level: extended
+      type: keyword
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -229,11 +229,13 @@
     - name: origin_referrer_url
       level: extended
       type: keyword
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
       example: https://example.com
 
     - name: origin_url
       level: extended
       type: keyword
+      ignore_above: 8192
       description: The url where the file is hosted.
       example: https://example.com/file.zip

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -230,12 +230,12 @@
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url of the webpage that linked to the file.
+      description: The URL of the webpage that linked to the file.
       example: https://example.com
 
     - name: origin_url
       level: extended
       type: keyword
       ignore_above: 8192
-      description: The url where the file is hosted.
+      description: The URL where the file is hosted.
       example: https://example.com/file.zip


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->
## Checklist
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? 
  - **YES**
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)?
  - **YES**
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)?
  -  **Not substantial changes** 
- If submitting code/script changes, have you verified all tests pass locally using `make test`? 
  - **Not code/script changes changes**
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
  - **YES**
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
  - **YES**
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)?
  - **YES**

## PR summary

This PR adds `file.origin_referrer_url` and `file.origin_url`

### To reviewers

**Size of the fields**
The two fields added in this PR are intended to store URL. Therefore, the default field size of 1024 bytes is insufficient. As a result, we want to set ignore_above to 8k(8192) bytes, if possible.

**Default Field**
This field will not necessarily be included in all file events.
Therefore, I set it as `default_field: false`, but please let me know if this is incorrect.