### PR TITLE
Revert "Add .caseless subfield to process.name & process.executable"

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -25,8 +25,6 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Added `.caseless` subfield to `process.name` and `process.executable`. #2341
-
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8128,9 +8128,6 @@ type: keyword
 
 Multi-fields:
 
-* process.executable.caseless (type: keyword)
-
-
 * process.executable.text (type: match_only_text)
 
 
@@ -8345,9 +8342,6 @@ Sometimes called program name or similar.
 type: keyword
 
 Multi-fields:
-
-* process.name.caseless (type: keyword)
-
 
 * process.name.text (type: match_only_text)
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5175,10 +5175,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5217,10 +5213,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5490,11 +5482,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5573,10 +5560,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5615,10 +5598,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -6033,11 +6012,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6427,10 +6401,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6674,10 +6644,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7264,10 +7230,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7383,10 +7345,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7425,10 +7383,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -648,13 +648,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 8.12.0-dev+exp,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
 8.12.0-dev+exp,true,process,process.entry_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.entry_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.entry_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.entry_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.entry_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.entry_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.entry_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.entry_leader.parent.pid,long,core,,4242,Process id.
@@ -690,7 +688,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.12.0-dev+exp,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.12.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -701,13 +698,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.group_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.group_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.group_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.group_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.group_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.group_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.group_leader.pid,long,core,,4242,Process id.
 8.12.0-dev+exp,true,process,process.group_leader.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -767,7 +762,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -823,7 +817,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.end,date,extended,,2016-05-23T08:05:34.853Z,The time the process ended.
 8.12.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.parent.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev+exp,true,process,process.parent.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -857,7 +850,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev+exp,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.parent.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.12.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -941,7 +933,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.previous.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.previous.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.real_group.name,keyword,extended,,,Name of the group.
@@ -959,13 +950,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.session_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev+exp,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev+exp,true,process,process.session_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev+exp,true,process,process.session_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.session_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev+exp,true,process,process.session_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev+exp,true,process,process.session_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev+exp,true,process,process.session_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev+exp,true,process,process.session_leader.parent.pid,long,core,,4242,Process id.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8426,11 +8426,6 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8492,11 +8487,6 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8920,11 +8910,6 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -9044,11 +9029,6 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -9110,11 +9090,6 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9804,11 +9779,6 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10470,11 +10440,6 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10884,11 +10849,6 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11873,11 +11833,6 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.previous.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -12063,11 +12018,6 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -12129,11 +12079,6 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10636,11 +10636,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10702,11 +10697,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11130,11 +11120,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11254,11 +11239,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11320,11 +11300,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -12018,11 +11993,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12685,11 +12655,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -13100,11 +13065,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -14091,11 +14051,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.previous.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14281,11 +14236,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14347,11 +14297,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -275,11 +275,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -304,11 +299,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -481,11 +471,6 @@
             },
             "executable": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -531,11 +516,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -560,11 +540,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -824,11 +799,6 @@
             },
             "name": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -1044,11 +1014,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1183,11 +1148,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1544,11 +1504,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1639,11 +1594,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1668,11 +1618,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2996,11 +2996,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3025,11 +3020,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3202,11 +3192,6 @@
           },
           "executable": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3252,11 +3237,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3281,11 +3261,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3545,11 +3520,6 @@
           },
           "name": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3765,11 +3735,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3904,11 +3869,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4265,11 +4225,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4360,11 +4315,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4389,11 +4339,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5125,10 +5125,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5167,10 +5163,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5440,11 +5432,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -5523,10 +5510,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -5565,10 +5548,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -5983,11 +5962,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
-        default_field: false
       - name: text
         type: match_only_text
         default_field: false
@@ -6377,10 +6351,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -6624,10 +6594,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.
@@ -7214,10 +7180,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7333,10 +7295,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: Absolute path to the process executable.
@@ -7375,10 +7333,6 @@
       type: keyword
       ignore_above: 1024
       multi_fields:
-      - name: caseless
-        type: keyword
-        normalizer: lowercase
-        ignore_above: 1024
       - name: text
         type: match_only_text
       description: 'Process name.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -641,13 +641,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.entry_leader.entry_meta.source.ip,ip,core,,,IP address of the source.
 8.12.0-dev,true,process,process.entry_leader.entry_meta.type,keyword,extended,,,The entry type for the entry session leader.
 8.12.0-dev,true,process,process.entry_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.entry_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.entry_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.entry_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.entry_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.entry_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.entry_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev,true,process,process.entry_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.entry_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.entry_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.entry_leader.parent.pid,long,core,,4242,Process id.
@@ -683,7 +681,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.12.0-dev,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.12.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev,true,process,process.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -694,13 +691,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.group_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev,true,process,process.group_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.group_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.group_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.group_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.group_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.group_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.group_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.group_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev,true,process,process.group_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.group_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.group_leader.pid,long,core,,4242,Process id.
 8.12.0-dev,true,process,process.group_leader.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -760,7 +755,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
-8.12.0-dev,true,process,process.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -816,7 +810,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.parent.end,date,extended,,2016-05-23T08:05:34.853Z,The time the process ended.
 8.12.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.parent.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.12.0-dev,true,process,process.parent.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -850,7 +843,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
 8.12.0-dev,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.12.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-8.12.0-dev,true,process,process.parent.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.12.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -934,7 +926,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev,true,process,process.previous.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev,true,process,process.previous.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.previous.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.previous.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.real_group.name,keyword,extended,,,Name of the group.
@@ -952,13 +943,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.session_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.12.0-dev,true,process,process.session_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.session_leader.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.12.0-dev,true,process,process.session_leader.executable.caseless,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.session_leader.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.session_leader.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.12.0-dev,true,process,process.session_leader.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.session_leader.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.12.0-dev,true,process,process.session_leader.name,keyword,extended,,ssh,Process name.
-8.12.0-dev,true,process,process.session_leader.name.caseless,keyword,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.session_leader.name.text,match_only_text,extended,,ssh,Process name.
 8.12.0-dev,true,process,process.session_leader.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.12.0-dev,true,process,process.session_leader.parent.pid,long,core,,4242,Process id.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8357,11 +8357,6 @@ process.entry_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.executable.text
     name: text
     type: match_only_text
@@ -8423,11 +8418,6 @@ process.entry_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.entry_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.entry_leader.name.text
     name: text
     type: match_only_text
@@ -8851,11 +8841,6 @@ process.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.executable.text
     name: text
     type: match_only_text
@@ -8975,11 +8960,6 @@ process.group_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.executable.text
     name: text
     type: match_only_text
@@ -9041,11 +9021,6 @@ process.group_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.group_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.group_leader.name.text
     name: text
     type: match_only_text
@@ -9735,11 +9710,6 @@ process.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.name.text
     name: text
     type: match_only_text
@@ -10401,11 +10371,6 @@ process.parent.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.executable.text
     name: text
     type: match_only_text
@@ -10815,11 +10780,6 @@ process.parent.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.parent.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.parent.name.text
     name: text
     type: match_only_text
@@ -11804,11 +11764,6 @@ process.previous.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.previous.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.previous.executable.text
     name: text
     type: match_only_text
@@ -11994,11 +11949,6 @@ process.session_leader.executable:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.executable.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.executable.text
     name: text
     type: match_only_text
@@ -12060,11 +12010,6 @@ process.session_leader.name:
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: process.session_leader.name.caseless
-    ignore_above: 1024
-    name: caseless
-    normalizer: lowercase
-    type: keyword
   - flat_name: process.session_leader.name.text
     name: text
     type: match_only_text

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10556,11 +10556,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.executable.text
         name: text
         type: match_only_text
@@ -10622,11 +10617,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.entry_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.entry_leader.name.text
         name: text
         type: match_only_text
@@ -11050,11 +11040,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.executable.text
         name: text
         type: match_only_text
@@ -11174,11 +11159,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.executable.text
         name: text
         type: match_only_text
@@ -11240,11 +11220,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.group_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.group_leader.name.text
         name: text
         type: match_only_text
@@ -11938,11 +11913,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.name.text
         name: text
         type: match_only_text
@@ -12605,11 +12575,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.executable.text
         name: text
         type: match_only_text
@@ -13020,11 +12985,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.parent.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.parent.name.text
         name: text
         type: match_only_text
@@ -14011,11 +13971,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.previous.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.previous.executable.text
         name: text
         type: match_only_text
@@ -14201,11 +14156,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.executable.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.executable.text
         name: text
         type: match_only_text
@@ -14267,11 +14217,6 @@ process:
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: process.session_leader.name.caseless
-        ignore_above: 1024
-        name: caseless
-        normalizer: lowercase
-        type: keyword
       - flat_name: process.session_leader.name.text
         name: text
         type: match_only_text

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -275,11 +275,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -304,11 +299,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -481,11 +471,6 @@
             },
             "executable": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -531,11 +516,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -560,11 +540,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -824,11 +799,6 @@
             },
             "name": {
               "fields": {
-                "caseless": {
-                  "ignore_above": 1024,
-                  "normalizer": "lowercase",
-                  "type": "keyword"
-                },
                 "text": {
                   "type": "match_only_text"
                 }
@@ -1044,11 +1014,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1183,11 +1148,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1544,11 +1504,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1639,11 +1594,6 @@
                 },
                 "executable": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }
@@ -1668,11 +1618,6 @@
                 },
                 "name": {
                   "fields": {
-                    "caseless": {
-                      "ignore_above": 1024,
-                      "normalizer": "lowercase",
-                      "type": "keyword"
-                    },
                     "text": {
                       "type": "match_only_text"
                     }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2954,11 +2954,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -2983,11 +2978,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3160,11 +3150,6 @@
           },
           "executable": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3210,11 +3195,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3239,11 +3219,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3503,11 +3478,6 @@
           },
           "name": {
             "fields": {
-              "caseless": {
-                "ignore_above": 1024,
-                "normalizer": "lowercase",
-                "type": "keyword"
-              },
               "text": {
                 "type": "match_only_text"
               }
@@ -3723,11 +3693,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -3862,11 +3827,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4223,11 +4183,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4318,11 +4273,6 @@
               },
               "executable": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }
@@ -4347,11 +4297,6 @@
               },
               "name": {
                 "fields": {
-                  "caseless": {
-                    "ignore_above": 1024,
-                    "normalizer": "lowercase",
-                    "type": "keyword"
-                  },
                   "text": {
                     "type": "match_only_text"
                   }

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -112,10 +112,6 @@
         Sometimes called program name or similar.
       example: ssh
       multi_fields:
-        - name: caseless
-          ignore_above: 1024
-          normalizer: lowercase
-          type: keyword
         - type: match_only_text
           name: text
 
@@ -175,10 +171,6 @@
         Absolute path to the process executable.
       example: /usr/bin/ssh
       multi_fields:
-        - name: caseless
-          ignore_above: 1024
-          normalizer: lowercase
-          type: keyword
         - type: match_only_text
           name: text
 


### PR DESCRIPTION
Reverts elastic/ecs#2341

This is being reverted due to storage concerns. The goal will be to advance the native querying capabilities (ES|QL, KQL) of the Elastic stack such that this extra normalized multi-field is not necessary. In the meantime, localized overrides of the ECS field definition will be used to add the additional multi-field where needed. The downside of localized overrides are that it creates inconsistency across usages of the this field.