### PR TITLE
Update the stale PR bot message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,18 @@ jobs:
       uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity.'
+        stale-pr-message: |
+          Hi!
+
+          We just realized that we haven't looked into this PR in a while. We're
+          sorry!
+
+          We're labeling this PR as `Stale` to make it hit our filters and
+          make sure we get back to it as soon as possible. In the meantime, it'd
+          be extremely helpful if you could take a look at it as well and confirm its
+          relevance. A simple comment with a nice emoji will be enough `:+1`.
+
+          Thank you for your contribution!
         stale-pr-label: 'stale'
         ascending: true
         days-before-pr-stale: 60


### PR DESCRIPTION
Add a friendlier stale PR message, based from the [Beats stale message](https://github.com/elastic/beats/blob/main/.github/stale.yml#L63-L74).

This will hopefully also prompt contributors to respond, so we'll be better able to track PRs people are still interested in contributing.

--- 
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? n/a
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? n/a
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? n/a
