### PR TITLE
Add check for missing license headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,6 @@ jobs:
         with:
           python-version: '3.x'
       - run: git fetch --prune --unshallow --tags
+      - run: make check_license_headers
       - run: make check
+

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ check_license_headers:
 	@echo "Files missing license headers:\n"
 	@find . -type f \( -path './scripts/*' -o -path './schemas/*' \) \
 	\( -name '*.py' -o -name '*.yml' \) \
-	-print0 | xargs -0 -n1 grep -L "Licensed to Elasticsearch B.V." \
-	|| exit 0
+	-print0 | xargs -0 -n1 grep -L "Licensed to Elasticsearch B.V."
 
 # Clean deletes all temporary and generated content.
 .PHONY: clean
@@ -86,7 +85,7 @@ misspell:
 	fi
 	./build/misspell/bin/misspell -error README.md CONTRIBUTING.md schemas/* docs/* experimental/schemas/*
 
-# Warn re misspell removal     
+# Warn re misspell removal
 .PHONY: misspell_warn
 misspell_warn:
 	@echo "Warning: due to lack of cross-platform support, misspell is no longer included in this task and may be deprecated in future\n"


### PR DESCRIPTION
Add `make check_license_headers` as a test workflow step, in order to detect any yaml or py files without the required license header.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? n/a
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? n/a
