### PR TITLE
Fix type in code signature

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -873,7 +873,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The flags used to sign the process.
 
-type: string
+type: keyword
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1273,7 +1273,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -2439,7 +2440,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -4793,7 +4795,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -6117,7 +6120,8 @@
       default_field: false
     - name: parent.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -9177,7 +9181,8 @@
       default_field: false
     - name: enrichments.indicator.file.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -10798,7 +10803,8 @@
       default_field: false
     - name: indicator.file.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -149,7 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,device,device.serial_number,keyword,core,,DJGAQS4CW5,Serial Number of the device
 8.12.0-dev+exp,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,dll,dll.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,dll,dll.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -280,7 +280,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev+exp,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,file,file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,file,file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -593,7 +593,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,process,process.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,process,process.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -775,7 +775,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,process,process.parent.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,process,process.parent.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -1162,7 +1162,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -1381,7 +1381,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1806,12 +1806,13 @@ dll.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: dll.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 dll.code_signature.signing_id:
   dashed_name: dll-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -3957,12 +3958,13 @@ file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 file.code_signature.signing_id:
   dashed_name: file-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -7787,12 +7789,13 @@ process.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: process.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 process.code_signature.signing_id:
   dashed_name: process-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -9956,12 +9959,13 @@ process.parent.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: process.parent.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 process.parent.code_signature.signing_id:
   dashed_name: process-parent-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -14782,12 +14786,13 @@ threat.enrichments.indicator.file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: threat.enrichments.indicator.file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 threat.enrichments.indicator.file.code_signature.signing_id:
   dashed_name: threat-enrichments-indicator-file-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -17518,12 +17523,13 @@ threat.indicator.file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: threat.indicator.file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 threat.indicator.file.code_signature.signing_id:
   dashed_name: threat-indicator-file-code-signature-signing-id
   description: 'The identifier used to sign the process.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1326,11 +1326,12 @@ code_signature:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       short: Code signing flags of the process
-      type: string
+      type: keyword
     code_signature.signing_id:
       dashed_name: code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -2290,12 +2291,13 @@ dll:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: dll.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     dll.code_signature.signing_id:
       dashed_name: dll-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -5001,12 +5003,13 @@ file:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     file.code_signature.signing_id:
       dashed_name: file-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -10020,12 +10023,13 @@ process:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: process.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     process.code_signature.signing_id:
       dashed_name: process-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -12194,12 +12198,13 @@ process:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: process.parent.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     process.parent.code_signature.signing_id:
       dashed_name: process-parent-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -17482,12 +17487,13 @@ threat:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: threat.enrichments.indicator.file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     threat.enrichments.indicator.file.code_signature.signing_id:
       dashed_name: threat-enrichments-indicator-file-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -20224,12 +20230,13 @@ threat:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: threat.indicator.file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     threat.indicator.file.code_signature.signing_id:
       dashed_name: threat-indicator-file-code-signature-signing-id
       description: 'The identifier used to sign the process.

--- a/experimental/generated/elasticsearch/composable/component/dll.json
+++ b/experimental/generated/elasticsearch/composable/component/dll.json
@@ -18,7 +18,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -25,7 +25,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -25,7 +25,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,
@@ -832,7 +833,8 @@
                       "type": "boolean"
                     },
                     "flags": {
-                      "type": "string"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "signing_id": {
                       "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -67,7 +67,8 @@
                               "type": "boolean"
                             },
                             "flags": {
-                              "type": "string"
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "signing_id": {
                               "ignore_above": 1024,
@@ -995,7 +996,8 @@
                           "type": "boolean"
                         },
                         "flags": {
-                          "type": "string"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "signing_id": {
                           "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -801,7 +801,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -1376,7 +1377,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -2768,7 +2770,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -3575,7 +3578,8 @@
                     "type": "boolean"
                   },
                   "flags": {
-                    "type": "string"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "signing_id": {
                     "ignore_above": 1024,
@@ -5320,7 +5324,8 @@
                             "type": "boolean"
                           },
                           "flags": {
-                            "type": "string"
+                            "ignore_above": 1024,
+                            "type": "keyword"
                           },
                           "signing_id": {
                             "ignore_above": 1024,
@@ -6248,7 +6253,8 @@
                         "type": "boolean"
                       },
                       "flags": {
-                        "type": "string"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "signing_id": {
                         "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1223,7 +1223,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -2389,7 +2390,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -4743,7 +4745,8 @@
       default_field: false
     - name: code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -6067,7 +6070,8 @@
       default_field: false
     - name: parent.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -9127,7 +9131,8 @@
       default_field: false
     - name: enrichments.indicator.file.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false
@@ -10748,7 +10753,8 @@
       default_field: false
     - name: indicator.file.code_signature.flags
       level: extended
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: The flags used to sign the process.
       example: 570522385
       default_field: false

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -142,7 +142,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,device,device.serial_number,keyword,core,,DJGAQS4CW5,Serial Number of the device
 8.12.0-dev,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,dll,dll.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,dll,dll.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -273,7 +273,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,file,file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,file,file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -586,7 +586,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,process,process.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,process,process.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -768,7 +768,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,process,process.parent.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,process,process.parent.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -1155,7 +1155,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -1374,7 +1374,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.12.0-dev,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.12.0-dev,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-8.12.0-dev,true,threat,threat.indicator.file.code_signature.flags,string,extended,,570522385,Code signing flags of the process
+8.12.0-dev,true,threat,threat.indicator.file.code_signature.flags,keyword,extended,,570522385,Code signing flags of the process
 8.12.0-dev,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.12.0-dev,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.12.0-dev,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1737,12 +1737,13 @@ dll.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: dll.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 dll.code_signature.signing_id:
   dashed_name: dll-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -3888,12 +3889,13 @@ file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 file.code_signature.signing_id:
   dashed_name: file-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -7718,12 +7720,13 @@ process.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: process.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 process.code_signature.signing_id:
   dashed_name: process-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -9887,12 +9890,13 @@ process.parent.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: process.parent.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 process.parent.code_signature.signing_id:
   dashed_name: process-parent-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -14713,12 +14717,13 @@ threat.enrichments.indicator.file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: threat.enrichments.indicator.file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 threat.enrichments.indicator.file.code_signature.signing_id:
   dashed_name: threat-enrichments-indicator-file-code-signature-signing-id
   description: 'The identifier used to sign the process.
@@ -17449,12 +17454,13 @@ threat.indicator.file.code_signature.flags:
   description: The flags used to sign the process.
   example: 570522385
   flat_name: threat.indicator.file.code_signature.flags
+  ignore_above: 1024
   level: extended
   name: flags
   normalize: []
   original_fieldset: code_signature
   short: Code signing flags of the process
-  type: string
+  type: keyword
 threat.indicator.file.code_signature.signing_id:
   dashed_name: threat-indicator-file-code-signature-signing-id
   description: 'The identifier used to sign the process.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1246,11 +1246,12 @@ code_signature:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       short: Code signing flags of the process
-      type: string
+      type: keyword
     code_signature.signing_id:
       dashed_name: code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -2210,12 +2211,13 @@ dll:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: dll.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     dll.code_signature.signing_id:
       dashed_name: dll-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -4921,12 +4923,13 @@ file:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     file.code_signature.signing_id:
       dashed_name: file-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -9940,12 +9943,13 @@ process:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: process.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     process.code_signature.signing_id:
       dashed_name: process-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -12114,12 +12118,13 @@ process:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: process.parent.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     process.parent.code_signature.signing_id:
       dashed_name: process-parent-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -17402,12 +17407,13 @@ threat:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: threat.enrichments.indicator.file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     threat.enrichments.indicator.file.code_signature.signing_id:
       dashed_name: threat-enrichments-indicator-file-code-signature-signing-id
       description: 'The identifier used to sign the process.
@@ -20144,12 +20150,13 @@ threat:
       description: The flags used to sign the process.
       example: 570522385
       flat_name: threat.indicator.file.code_signature.flags
+      ignore_above: 1024
       level: extended
       name: flags
       normalize: []
       original_fieldset: code_signature
       short: Code signing flags of the process
-      type: string
+      type: keyword
     threat.indicator.file.code_signature.signing_id:
       dashed_name: threat-indicator-file-code-signature-signing-id
       description: 'The identifier used to sign the process.

--- a/generated/elasticsearch/composable/component/dll.json
+++ b/generated/elasticsearch/composable/component/dll.json
@@ -18,7 +18,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -25,7 +25,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -25,7 +25,8 @@
                   "type": "boolean"
                 },
                 "flags": {
-                  "type": "string"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "signing_id": {
                   "ignore_above": 1024,
@@ -832,7 +833,8 @@
                       "type": "boolean"
                     },
                     "flags": {
-                      "type": "string"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "signing_id": {
                       "ignore_above": 1024,

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -67,7 +67,8 @@
                               "type": "boolean"
                             },
                             "flags": {
-                              "type": "string"
+                              "ignore_above": 1024,
+                              "type": "keyword"
                             },
                             "signing_id": {
                               "ignore_above": 1024,
@@ -995,7 +996,8 @@
                           "type": "boolean"
                         },
                         "flags": {
-                          "type": "string"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "signing_id": {
                           "ignore_above": 1024,

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -759,7 +759,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -1334,7 +1335,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -2726,7 +2728,8 @@
                 "type": "boolean"
               },
               "flags": {
-                "type": "string"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "signing_id": {
                 "ignore_above": 1024,
@@ -3533,7 +3536,8 @@
                     "type": "boolean"
                   },
                   "flags": {
-                    "type": "string"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "signing_id": {
                     "ignore_above": 1024,
@@ -5278,7 +5282,8 @@
                             "type": "boolean"
                           },
                           "flags": {
-                            "type": "string"
+                            "ignore_above": 1024,
+                            "type": "keyword"
                           },
                           "signing_id": {
                             "ignore_above": 1024,
@@ -6206,7 +6211,8 @@
                         "type": "boolean"
                       },
                       "flags": {
-                        "type": "string"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "signing_id": {
                         "ignore_above": 1024,

--- a/rfcs/text/0044/code_signature.yml
+++ b/rfcs/text/0044/code_signature.yml
@@ -3,7 +3,7 @@
   fields:
     - name: flags
       level: extended
-      type: string
+      type: keyword
       short: Code signing flags of the process
       description: >
           The flags used to sign the process.

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -37,7 +37,7 @@
 
     - name: flags
       level: extended
-      type: string
+      type: keyword
       short: Code signing flags of the process
       description: >
           The flags used to sign the process.

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -130,6 +130,41 @@ class TestEcsSpec(unittest.TestCase):
         for (field_name, field) in self.ecs_fields.items():
             self.assertIsInstance(field.get('normalize'), list, field_name)
 
+    def test_valid_type(self):
+        valid_types = ['binary',
+                       'boolean',
+                       'keyword',
+                       'constant_keyword',
+                       'wildcard',
+                       'long',
+                       'integer',
+                       'short',
+                       'byte',
+                       'double',
+                       'float',
+                       'half_float',
+                       'scaled_float',
+                       'unsigned_long',
+                       'date',
+                       'date_nanos',
+                       'alias',
+                       'object',
+                       'flattened',
+                       'nested',
+                       'join',
+                       'long_range',
+                       'double_range',
+                       'date_range',
+                       'ip',
+                       'text',
+                       'match_only_text',
+                       'geo_point',
+                       'geo_shape',
+                       'point',
+                       'shape']
+        for (field_name, field) in self.ecs_fields.items():
+            self.assertIn(field.get('type'), valid_types, field_name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Change the type of `code_signature.flags` to `keyword`, which is what it should be. Also add a unit test that will verify all types are valid.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?   ✅
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? ✅
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? ✅
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? ✅
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? n/a
