### PR TITLE
Define base encoding in x509.serial_number

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -25,6 +25,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Define base encoding of `x509.serial_number`. #2383
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -13803,7 +13803,7 @@ example: `2048`
 [[field-x509-serial-number]]
 <<field-x509-serial-number, x509.serial_number>>
 
-a| Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters.
+a| Unique serial number issued by the certificate authority. For consistency, this should be encoded in base 16 and formatted without colons and uppercase characters.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3337,7 +3337,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -9979,7 +9979,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -10536,7 +10536,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -11600,7 +11600,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12168,7 +12168,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12584,7 +12584,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12866,7 +12866,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5508,8 +5508,7 @@ file.x509.public_key_size:
 file.x509.serial_number:
   dashed_name: file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: file.x509.serial_number
   ignore_above: 1024
@@ -16155,8 +16154,7 @@ threat.enrichments.indicator.file.x509.public_key_size:
 threat.enrichments.indicator.file.x509.serial_number:
   dashed_name: threat-enrichments-indicator-file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.enrichments.indicator.file.x509.serial_number
   ignore_above: 1024
@@ -17082,8 +17080,7 @@ threat.enrichments.indicator.x509.public_key_size:
 threat.enrichments.indicator.x509.serial_number:
   dashed_name: threat-enrichments-indicator-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.enrichments.indicator.x509.serial_number
   ignore_above: 1024
@@ -18891,8 +18888,7 @@ threat.indicator.file.x509.public_key_size:
 threat.indicator.file.x509.serial_number:
   dashed_name: threat-indicator-file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.indicator.file.x509.serial_number
   ignore_above: 1024
@@ -19834,8 +19830,7 @@ threat.indicator.x509.public_key_size:
 threat.indicator.x509.serial_number:
   dashed_name: threat-indicator-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.indicator.x509.serial_number
   ignore_above: 1024
@@ -20525,8 +20520,7 @@ tls.client.x509.public_key_size:
 tls.client.x509.serial_number:
   dashed_name: tls-client-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: tls.client.x509.serial_number
   ignore_above: 1024
@@ -21002,8 +20996,7 @@ tls.server.x509.public_key_size:
 tls.server.x509.serial_number:
   dashed_name: tls-server-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: tls.server.x509.serial_number
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6555,7 +6555,7 @@ file:
     file.x509.serial_number:
       dashed_name: file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: file.x509.serial_number
@@ -18857,7 +18857,7 @@ threat:
     threat.enrichments.indicator.file.x509.serial_number:
       dashed_name: threat-enrichments-indicator-file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.enrichments.indicator.file.x509.serial_number
@@ -19788,7 +19788,7 @@ threat:
     threat.enrichments.indicator.x509.serial_number:
       dashed_name: threat-enrichments-indicator-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.enrichments.indicator.x509.serial_number
@@ -21599,7 +21599,7 @@ threat:
     threat.indicator.file.x509.serial_number:
       dashed_name: threat-indicator-file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.indicator.file.x509.serial_number
@@ -22546,7 +22546,7 @@ threat:
     threat.indicator.x509.serial_number:
       dashed_name: threat-indicator-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.indicator.x509.serial_number
@@ -23301,7 +23301,7 @@ tls:
     tls.client.x509.serial_number:
       dashed_name: tls-client-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: tls.client.x509.serial_number
@@ -23781,7 +23781,7 @@ tls:
     tls.server.x509.serial_number:
       dashed_name: tls-server-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: tls.server.x509.serial_number
@@ -25699,7 +25699,7 @@ x509:
     x509.serial_number:
       dashed_name: x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: x509.serial_number

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3287,7 +3287,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -9929,7 +9929,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -10486,7 +10486,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -11550,7 +11550,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12118,7 +12118,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12534,7 +12534,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false
@@ -12816,7 +12816,7 @@
       type: keyword
       ignore_above: 1024
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       default_field: false

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5439,8 +5439,7 @@ file.x509.public_key_size:
 file.x509.serial_number:
   dashed_name: file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: file.x509.serial_number
   ignore_above: 1024
@@ -16086,8 +16085,7 @@ threat.enrichments.indicator.file.x509.public_key_size:
 threat.enrichments.indicator.file.x509.serial_number:
   dashed_name: threat-enrichments-indicator-file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.enrichments.indicator.file.x509.serial_number
   ignore_above: 1024
@@ -17013,8 +17011,7 @@ threat.enrichments.indicator.x509.public_key_size:
 threat.enrichments.indicator.x509.serial_number:
   dashed_name: threat-enrichments-indicator-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.enrichments.indicator.x509.serial_number
   ignore_above: 1024
@@ -18822,8 +18819,7 @@ threat.indicator.file.x509.public_key_size:
 threat.indicator.file.x509.serial_number:
   dashed_name: threat-indicator-file-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.indicator.file.x509.serial_number
   ignore_above: 1024
@@ -19765,8 +19761,7 @@ threat.indicator.x509.public_key_size:
 threat.indicator.x509.serial_number:
   dashed_name: threat-indicator-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: threat.indicator.x509.serial_number
   ignore_above: 1024
@@ -20456,8 +20451,7 @@ tls.client.x509.public_key_size:
 tls.client.x509.serial_number:
   dashed_name: tls-client-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: tls.client.x509.serial_number
   ignore_above: 1024
@@ -20933,8 +20927,7 @@ tls.server.x509.public_key_size:
 tls.server.x509.serial_number:
   dashed_name: tls-server-x509-serial-number
   description: Unique serial number issued by the certificate authority. For consistency,
-    if this value is alphanumeric, it should be formatted without colons and uppercase
-    characters.
+    this should be encoded in base 16 and formatted without colons and uppercase characters.
   example: 55FBB9C7DEBF09809D12CCAA
   flat_name: tls.server.x509.serial_number
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6475,7 +6475,7 @@ file:
     file.x509.serial_number:
       dashed_name: file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: file.x509.serial_number
@@ -18777,7 +18777,7 @@ threat:
     threat.enrichments.indicator.file.x509.serial_number:
       dashed_name: threat-enrichments-indicator-file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.enrichments.indicator.file.x509.serial_number
@@ -19708,7 +19708,7 @@ threat:
     threat.enrichments.indicator.x509.serial_number:
       dashed_name: threat-enrichments-indicator-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.enrichments.indicator.x509.serial_number
@@ -21519,7 +21519,7 @@ threat:
     threat.indicator.file.x509.serial_number:
       dashed_name: threat-indicator-file-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.indicator.file.x509.serial_number
@@ -22466,7 +22466,7 @@ threat:
     threat.indicator.x509.serial_number:
       dashed_name: threat-indicator-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: threat.indicator.x509.serial_number
@@ -23221,7 +23221,7 @@ tls:
     tls.client.x509.serial_number:
       dashed_name: tls-client-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: tls.client.x509.serial_number
@@ -23701,7 +23701,7 @@ tls:
     tls.server.x509.serial_number:
       dashed_name: tls-server-x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: tls.server.x509.serial_number
@@ -25619,7 +25619,7 @@ x509:
     x509.serial_number:
       dashed_name: x509-serial-number
       description: Unique serial number issued by the certificate authority. For consistency,
-        if this value is alphanumeric, it should be formatted without colons and uppercase
+        this should be encoded in base 16 and formatted without colons and uppercase
         characters.
       example: 55FBB9C7DEBF09809D12CCAA
       flat_name: x509.serial_number

--- a/schemas/x509.yml
+++ b/schemas/x509.yml
@@ -52,8 +52,8 @@
       type: keyword
       short: Unique serial number issued by the certificate authority.
       description: >
-        Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be
-        formatted without colons and uppercase characters.
+        Unique serial number issued by the certificate authority. For consistency, this should be
+        encoded in base 16 and formatted without colons and uppercase characters.
       example: 55FBB9C7DEBF09809D12CCAA
 
     - name: issuer.distinguished_name


### PR DESCRIPTION
This proposes enforcing the base encoding of x509.serial_number to be 16.

The current definition is too loose and leaves room for interpretation, base 16 is also more common and it will help users correlate the value with existing tools. This change was prompted by elastic/sdh-beats#5089 where a customer expected to see it in the same format as other tools.

Particularly relevant comment from @andrewkroh here:  https://github.com/elastic/sdh-beats/issues/5089#issuecomment-2349046226
Narrow the definition of x509.serial_number to be encoded in hexadecimal, otherwise we end up with integrations choosing their own encoding, as noted below, Zeek uses base 16 while the rest of beats is using base 10.
