### PR TITLE
Add domain to email.to and email.from

### DIFF
--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -126,6 +126,16 @@
       normalize:
         - array
 
+    - name: from.domain
+      level: extended
+      type: keyword
+      short: The sender's email domain.
+      description: >
+        The domain of the email sender.
+      example: "example.com"
+      normalize:
+        - array
+
     - name: local_id
       level: extended
       type: keyword
@@ -190,6 +200,16 @@
       description: >
         The email address of recipient
       example: "user1@example.com"
+      normalize:
+        - array
+
+    - name: to.domain
+      level: extended
+      type: keyword
+      short: The recipient's email domain.
+      description: >
+        The domain of the email recipient.
+      example: "example.com"
       normalize:
         - array
 


### PR DESCRIPTION
This PR is to add `email.from.domain` and `email.to.domain` to ECS. These changes will help to visualize and report on emails sent to/from a specific domain/company. 

* Closes #2149 