### PR TITLE
Update template example in usage doc

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -372,7 +372,9 @@ This is an example `template.json` to be passed with `--template-setting-legacy`
       "refresh_interval": "1s"
     }
   },
-  "mappings": {}
+  "template": {
+    "mappings": {}
+  }
 }
 ```
 


### PR DESCRIPTION
The example for template.json in the usage doc for the custom template and mapping setting section was incorrect and did not work for both template types. This fixes the example to work with both.

---

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? n/a
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? n/a
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? n/a

Closes #2342
