### PR TITLE
Add support for synthetic_source_keep = none

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -20,6 +20,7 @@ Thanks, you're awesome :-) -->
 
 * Define base encoding of `x509.serial_number`. #2383
 * Restrict the encoding of `x509.serial_number` to base 16. #2398
+* Set synthetic_source_keep = none on fields with represent sets. #2422
 
 #### Deprecated
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -20,7 +20,7 @@ Thanks, you're awesome :-) -->
 
 * Define base encoding of `x509.serial_number`. #2383
 * Restrict the encoding of `x509.serial_number` to base 16. #2398
-* Set synthetic_source_keep = none on fields with represent sets. #2422
+* Set synthetic_source_keep = none on fields that represent sets. #2422
 
 #### Deprecated
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1187,6 +1187,7 @@ container.image.tag:
     relation: equivalent
     stability: experimental
   short: Container image tags.
+  synthetic_source_keep: none
   type: keyword
 container.labels:
   dashed_name: container-labels

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -20829,7 +20829,6 @@ tls.client.supported_ciphers:
   - relation: match
     stability: experimental
   short: Array of ciphers offered by the client during the client hello.
-  synthetic_source_keep: none
   type: keyword
 tls.client.x509.alternative_names:
   dashed_name: tls-client-x509-alternative-names

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -650,6 +650,7 @@ client.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
@@ -1791,6 +1792,7 @@ destination.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 device.id:
   dashed_name: device-id
@@ -2507,6 +2509,7 @@ dns.header_flags:
   normalize:
   - array
   short: Array of DNS header flags.
+  synthetic_source_keep: none
   type: keyword
 dns.id:
   dashed_name: dns-id
@@ -2844,6 +2847,7 @@ email.bcc.address:
   normalize:
   - array
   short: Email address of BCC recipient
+  synthetic_source_keep: none
   type: keyword
 email.cc.address:
   dashed_name: email-cc-address
@@ -2856,6 +2860,7 @@ email.cc.address:
   normalize:
   - array
   short: Email address of CC recipient
+  synthetic_source_keep: none
   type: keyword
 email.content_type:
   dashed_name: email-content-type
@@ -2904,6 +2909,7 @@ email.from.address:
   normalize:
   - array
   short: The sender's email address.
+  synthetic_source_keep: none
   type: keyword
 email.local_id:
   dashed_name: email-local-id
@@ -2953,6 +2959,7 @@ email.reply_to.address:
   normalize:
   - array
   short: Address replies should be delivered to.
+  synthetic_source_keep: none
   type: keyword
 email.sender.address:
   dashed_name: email-sender-address
@@ -2964,6 +2971,7 @@ email.sender.address:
   name: sender.address
   normalize: []
   short: Address of the message sender.
+  synthetic_source_keep: none
   type: keyword
 email.subject:
   dashed_name: email-subject
@@ -2991,6 +2999,7 @@ email.to.address:
   normalize:
   - array
   short: Email address of recipient
+  synthetic_source_keep: none
   type: keyword
 email.x_mailer:
   dashed_name: email-x-mailer
@@ -3348,6 +3357,7 @@ event.category:
   normalize:
   - array
   short: Event category. The second categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.code:
   dashed_name: event-code
@@ -3909,6 +3919,7 @@ event.type:
   normalize:
   - array
   short: Event type. The third categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.url:
   dashed_name: event-url
@@ -4059,6 +4070,7 @@ file.attributes:
   - relation: match
     stability: experimental
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 file.code_signature.digest_algorithm:
   dashed_name: file-code-signature-digest-algorithm
@@ -6128,6 +6140,7 @@ host.ip:
   - relation: match
     stability: experimental
   short: Host ip addresses.
+  synthetic_source_keep: none
   type: ip
 host.mac:
   dashed_name: host-mac
@@ -6148,6 +6161,7 @@ host.mac:
     stability: experimental
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
+  synthetic_source_keep: none
   type: keyword
 host.name:
   dashed_name: host-name
@@ -7506,6 +7520,7 @@ observer.ip:
   normalize:
   - array
   short: IP addresses of the observer.
+  synthetic_source_keep: none
   type: ip
 observer.mac:
   dashed_name: observer-mac
@@ -7523,6 +7538,7 @@ observer.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
+  synthetic_source_keep: none
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -7785,6 +7801,7 @@ orchestrator.resource.annotation:
   normalize:
   - array
   short: The list of annotations added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.id:
   dashed_name: orchestrator-resource-id
@@ -7807,6 +7824,7 @@ orchestrator.resource.ip:
   normalize:
   - array
   short: IP address assigned to the resource associated with the event being observed.
+  synthetic_source_keep: none
   type: ip
 orchestrator.resource.label:
   dashed_name: orchestrator-resource-label
@@ -7819,6 +7837,7 @@ orchestrator.resource.label:
   normalize:
   - array
   short: The list of labels added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
@@ -9318,6 +9337,7 @@ process.env_vars:
   normalize:
   - array
   short: Array of environment variable bindings.
+  synthetic_source_keep: none
   type: keyword
 process.executable:
   dashed_name: process-executable
@@ -11784,6 +11804,7 @@ process.parent.thread.capabilities.effective:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.capabilities.permitted:
   dashed_name: process-parent-thread-capabilities-permitted
@@ -11799,6 +11820,7 @@ process.parent.thread.capabilities.permitted:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
@@ -13010,6 +13032,7 @@ process.thread.capabilities.effective:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.thread.capabilities.permitted:
   dashed_name: process-thread-capabilities-permitted
@@ -13024,6 +13047,7 @@ process.thread.capabilities.permitted:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.thread.id:
   dashed_name: process-thread-id
@@ -13315,6 +13339,7 @@ related.hash:
   otel:
   - relation: na
   short: All the hashes seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.hosts:
   dashed_name: related-hosts
@@ -13329,6 +13354,7 @@ related.hosts:
   otel:
   - relation: na
   short: All the host identifiers seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.ip:
   dashed_name: related-ip
@@ -13341,6 +13367,7 @@ related.ip:
   otel:
   - relation: na
   short: All of the IPs seen on your event.
+  synthetic_source_keep: none
   type: ip
 related.user:
   dashed_name: related-user
@@ -13354,6 +13381,7 @@ related.user:
   otel:
   - relation: na
   short: All the user names or other user identifiers seen on the event.
+  synthetic_source_keep: none
   type: keyword
 rule.author:
   dashed_name: rule-author
@@ -13367,6 +13395,7 @@ rule.author:
   normalize:
   - array
   short: Rule author
+  synthetic_source_keep: none
   type: keyword
 rule.category:
   dashed_name: rule-category
@@ -13943,6 +13972,7 @@ server.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 service.address:
   dashed_name: service-address
@@ -14102,6 +14132,7 @@ service.node.roles:
   normalize:
   - array
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -14258,6 +14289,7 @@ service.origin.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -14467,6 +14499,7 @@ service.target.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.target.state:
   dashed_name: service-target-state
@@ -15010,6 +15043,7 @@ source.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 span.id:
   dashed_name: span-id
@@ -15040,6 +15074,7 @@ tags:
   normalize:
   - array
   short: List of keywords used to tag each event.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments:
   dashed_name: threat-enrichments
@@ -15051,6 +15086,7 @@ threat.enrichments:
   normalize:
   - array
   short: List of objects containing indicators enriching the event.
+  synthetic_source_keep: none
   type: nested
 threat.enrichments.indicator:
   dashed_name: threat-enrichments-indicator
@@ -15159,6 +15195,7 @@ threat.enrichments.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -17756,6 +17793,7 @@ threat.group.alias:
   normalize:
   - array
   short: Alias of the group.
+  synthetic_source_keep: none
   type: keyword
 threat.group.id:
   dashed_name: threat-group-id
@@ -17894,6 +17932,7 @@ threat.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -19591,6 +19630,7 @@ threat.indicator.id:
   normalize:
   - array
   short: ID of the indicator
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
@@ -20380,6 +20420,7 @@ threat.software.alias:
   normalize:
   - array
   short: Alias of the software
+  synthetic_source_keep: none
   type: keyword
 threat.software.id:
   dashed_name: threat-software-id
@@ -20431,6 +20472,7 @@ threat.software.platforms:
   normalize:
   - array
   short: Platforms of the software.
+  synthetic_source_keep: none
   type: keyword
 threat.software.reference:
   dashed_name: threat-software-reference
@@ -20787,6 +20829,7 @@ tls.client.supported_ciphers:
   - relation: match
     stability: experimental
   short: Array of ciphers offered by the client during the client hello.
+  synthetic_source_keep: none
   type: keyword
 tls.client.x509.alternative_names:
   dashed_name: tls-client-x509-alternative-names
@@ -22037,6 +22080,7 @@ user.changes.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.domain:
   dashed_name: user-domain
@@ -22180,6 +22224,7 @@ user.effective.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.email:
   dashed_name: user-email
@@ -22390,6 +22435,7 @@ user.roles:
   - relation: match
     stability: experimental
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.target.domain:
   dashed_name: user-target-domain
@@ -22521,6 +22567,7 @@ user.target.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user_agent.device.name:
   dashed_name: user-agent-device-name
@@ -22889,6 +22936,7 @@ vulnerability.category:
   normalize:
   - array
   short: Category of a vulnerability.
+  synthetic_source_keep: none
   type: keyword
 vulnerability.classification:
   dashed_name: vulnerability-classification

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -253,6 +253,7 @@ base:
       normalize:
       - array
       short: List of keywords used to tag each event.
+      synthetic_source_keep: none
       type: keyword
   group: 1
   name: base
@@ -826,6 +827,7 @@ client:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: client
@@ -2238,6 +2240,7 @@ destination:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: destination
@@ -3035,6 +3038,7 @@ dns:
       normalize:
       - array
       short: Array of DNS header flags.
+      synthetic_source_keep: none
       type: keyword
     dns.id:
       dashed_name: dns-id
@@ -3822,6 +3826,7 @@ email:
       normalize:
       - array
       short: Email address of BCC recipient
+      synthetic_source_keep: none
       type: keyword
     email.cc.address:
       dashed_name: email-cc-address
@@ -3834,6 +3839,7 @@ email:
       normalize:
       - array
       short: Email address of CC recipient
+      synthetic_source_keep: none
       type: keyword
     email.content_type:
       dashed_name: email-content-type
@@ -3883,6 +3889,7 @@ email:
       normalize:
       - array
       short: The sender's email address.
+      synthetic_source_keep: none
       type: keyword
     email.local_id:
       dashed_name: email-local-id
@@ -3932,6 +3939,7 @@ email:
       normalize:
       - array
       short: Address replies should be delivered to.
+      synthetic_source_keep: none
       type: keyword
     email.sender.address:
       dashed_name: email-sender-address
@@ -3943,6 +3951,7 @@ email:
       name: sender.address
       normalize: []
       short: Address of the message sender.
+      synthetic_source_keep: none
       type: keyword
     email.subject:
       dashed_name: email-subject
@@ -3970,6 +3979,7 @@ email:
       normalize:
       - array
       short: Email address of recipient
+      synthetic_source_keep: none
       type: keyword
     email.x_mailer:
       dashed_name: email-x-mailer
@@ -4368,6 +4378,7 @@ event:
       normalize:
       - array
       short: Event category. The second categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.code:
       dashed_name: event-code
@@ -4941,6 +4952,7 @@ event:
       normalize:
       - array
       short: Event type. The third categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.url:
       dashed_name: event-url
@@ -5117,6 +5129,7 @@ file:
       - relation: match
         stability: experimental
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     file.code_signature.digest_algorithm:
       dashed_name: file-code-signature-digest-algorithm
@@ -7594,6 +7607,7 @@ host:
       - relation: match
         stability: experimental
       short: Host ip addresses.
+      synthetic_source_keep: none
       type: ip
     host.mac:
       dashed_name: host-mac
@@ -7615,6 +7629,7 @@ host:
         stability: experimental
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
+      synthetic_source_keep: none
       type: keyword
     host.name:
       dashed_name: host-name
@@ -9284,6 +9299,7 @@ observer:
       normalize:
       - array
       short: IP addresses of the observer.
+      synthetic_source_keep: none
       type: ip
     observer.mac:
       dashed_name: observer-mac
@@ -9302,6 +9318,7 @@ observer:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
+      synthetic_source_keep: none
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -9601,6 +9618,7 @@ orchestrator:
       normalize:
       - array
       short: The list of annotations added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.id:
       dashed_name: orchestrator-resource-id
@@ -9624,6 +9642,7 @@ orchestrator:
       normalize:
       - array
       short: IP address assigned to the resource associated with the event being observed.
+      synthetic_source_keep: none
       type: ip
     orchestrator.resource.label:
       dashed_name: orchestrator-resource-label
@@ -9636,6 +9655,7 @@ orchestrator:
       normalize:
       - array
       short: The list of labels added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
@@ -11596,6 +11616,7 @@ process:
       normalize:
       - array
       short: Array of environment variable bindings.
+      synthetic_source_keep: none
       type: keyword
     process.executable:
       dashed_name: process-executable
@@ -14069,6 +14090,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.capabilities.permitted:
       dashed_name: process-parent-thread-capabilities-permitted
@@ -14084,6 +14106,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
@@ -15296,6 +15319,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.thread.capabilities.permitted:
       dashed_name: process-thread-capabilities-permitted
@@ -15310,6 +15334,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.thread.id:
       dashed_name: process-thread-id
@@ -15825,6 +15850,7 @@ related:
       otel:
       - relation: na
       short: All the hashes seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.hosts:
       dashed_name: related-hosts
@@ -15839,6 +15865,7 @@ related:
       otel:
       - relation: na
       short: All the host identifiers seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.ip:
       dashed_name: related-ip
@@ -15851,6 +15878,7 @@ related:
       otel:
       - relation: na
       short: All of the IPs seen on your event.
+      synthetic_source_keep: none
       type: ip
     related.user:
       dashed_name: related-user
@@ -15864,6 +15892,7 @@ related:
       otel:
       - relation: na
       short: All the user names or other user identifiers seen on the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: related
@@ -15986,6 +16015,7 @@ rule:
       normalize:
       - array
       short: Rule author
+      synthetic_source_keep: none
       type: keyword
     rule.category:
       dashed_name: rule-category
@@ -16589,6 +16619,7 @@ server:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: server
@@ -16776,6 +16807,7 @@ service:
       normalize:
       - array
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -16934,6 +16966,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -17145,6 +17178,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.target.state:
       dashed_name: service-target-state
@@ -17744,6 +17778,7 @@ source:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: source
@@ -17791,6 +17826,7 @@ threat:
       normalize:
       - array
       short: List of objects containing indicators enriching the event.
+      synthetic_source_keep: none
       type: nested
     threat.enrichments.indicator:
       dashed_name: threat-enrichments-indicator
@@ -17899,6 +17935,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.enrichments.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -20504,6 +20541,7 @@ threat:
       normalize:
       - array
       short: Alias of the group.
+      synthetic_source_keep: none
       type: keyword
     threat.group.id:
       dashed_name: threat-group-id
@@ -20642,6 +20680,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -22342,6 +22381,7 @@ threat:
       normalize:
       - array
       short: ID of the indicator
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
@@ -23136,6 +23176,7 @@ threat:
       normalize:
       - array
       short: Alias of the software
+      synthetic_source_keep: none
       type: keyword
     threat.software.id:
       dashed_name: threat-software-id
@@ -23187,6 +23228,7 @@ threat:
       normalize:
       - array
       short: Platforms of the software.
+      synthetic_source_keep: none
       type: keyword
     threat.software.reference:
       dashed_name: threat-software-reference
@@ -23607,6 +23649,7 @@ tls:
       - relation: match
         stability: experimental
       short: Array of ciphers offered by the client during the client hello.
+      synthetic_source_keep: none
       type: keyword
     tls.client.x509.alternative_names:
       dashed_name: tls-client-x509-alternative-names
@@ -24941,6 +24984,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.domain:
       dashed_name: user-domain
@@ -25084,6 +25128,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.email:
       dashed_name: user-email
@@ -25294,6 +25339,7 @@ user:
       - relation: match
         stability: experimental
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.target.domain:
       dashed_name: user-target-domain
@@ -25425,6 +25471,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: user
@@ -25958,6 +26005,7 @@ vulnerability:
       normalize:
       - array
       short: Category of a vulnerability.
+      synthetic_source_keep: none
       type: keyword
     vulnerability.classification:
       dashed_name: vulnerability-classification

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -23649,7 +23649,6 @@ tls:
       - relation: match
         stability: experimental
       short: Array of ciphers offered by the client during the client hello.
-      synthetic_source_keep: none
       type: keyword
     tls.client.x509.alternative_names:
       dashed_name: tls-client-x509-alternative-names

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1591,6 +1591,7 @@ container:
         relation: equivalent
         stability: experimental
       short: Container image tags.
+      synthetic_source_keep: none
       type: keyword
     container.labels:
       dashed_name: container-labels

--- a/experimental/generated/elasticsearch/composable/component/base.json
+++ b/experimental/generated/elasticsearch/composable/component/base.json
@@ -17,6 +17,7 @@
         },
         "tags": {
           "ignore_above": 1024,
+          "synthetic_source_keep": "none",
           "type": "keyword"
         }
       }

--- a/experimental/generated/elasticsearch/composable/component/client.json
+++ b/experimental/generated/elasticsearch/composable/component/client.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/container.json
+++ b/experimental/generated/elasticsearch/composable/component/container.json
@@ -54,6 +54,7 @@
                 },
                 "tag": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/destination.json
+++ b/experimental/generated/elasticsearch/composable/component/destination.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/dns.json
+++ b/experimental/generated/elasticsearch/composable/component/dns.json
@@ -34,6 +34,7 @@
             },
             "header_flags": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "id": {

--- a/experimental/generated/elasticsearch/composable/component/email.json
+++ b/experimental/generated/elasticsearch/composable/component/email.json
@@ -72,6 +72,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -80,6 +81,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -99,6 +101,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -117,6 +120,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -125,6 +129,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -142,6 +147,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/event.json
+++ b/experimental/generated/elasticsearch/composable/component/event.json
@@ -18,6 +18,7 @@
             },
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code": {
@@ -98,6 +99,7 @@
             },
             "type": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "url": {

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -13,6 +13,7 @@
             },
             "attributes": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code_signature": {

--- a/experimental/generated/elasticsearch/composable/component/host.json
+++ b/experimental/generated/elasticsearch/composable/component/host.json
@@ -110,6 +110,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/experimental/generated/elasticsearch/composable/component/observer.json
+++ b/experimental/generated/elasticsearch/composable/component/observer.json
@@ -138,6 +138,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/experimental/generated/elasticsearch/composable/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/composable/component/orchestrator.json
@@ -44,6 +44,7 @@
               "properties": {
                 "annotation": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -55,6 +56,7 @@
                 },
                 "label": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "name": {

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -471,6 +471,7 @@
             },
             "env_vars": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "executable": {
@@ -1342,10 +1343,12 @@
                       "properties": {
                         "effective": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "permitted": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         }
                       }
@@ -1821,10 +1824,12 @@
                   "properties": {
                     "effective": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "permitted": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/experimental/generated/elasticsearch/composable/component/related.json
+++ b/experimental/generated/elasticsearch/composable/component/related.json
@@ -10,10 +10,12 @@
           "properties": {
             "hash": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "hosts": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "ip": {
@@ -21,6 +23,7 @@
             },
             "user": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             }
           }

--- a/experimental/generated/elasticsearch/composable/component/rule.json
+++ b/experimental/generated/elasticsearch/composable/component/rule.json
@@ -10,6 +10,7 @@
           "properties": {
             "author": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "category": {

--- a/experimental/generated/elasticsearch/composable/component/server.json
+++ b/experimental/generated/elasticsearch/composable/component/server.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/service.json
+++ b/experimental/generated/elasticsearch/composable/component/service.json
@@ -40,6 +40,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -78,6 +79,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }
@@ -134,6 +136,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/experimental/generated/elasticsearch/composable/component/source.json
+++ b/experimental/generated/elasticsearch/composable/component/source.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -55,6 +55,7 @@
                         },
                         "attributes": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "code_signature": {
@@ -923,6 +924,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -984,6 +986,7 @@
                     },
                     "attributes": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "code_signature": {
@@ -1540,6 +1543,7 @@
                 },
                 "id": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "ip": {
@@ -1801,6 +1805,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -1813,6 +1818,7 @@
                 },
                 "platforms": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "reference": {

--- a/experimental/generated/elasticsearch/composable/component/tls.json
+++ b/experimental/generated/elasticsearch/composable/component/tls.json
@@ -62,7 +62,6 @@
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
-                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "x509": {

--- a/experimental/generated/elasticsearch/composable/component/tls.json
+++ b/experimental/generated/elasticsearch/composable/component/tls.json
@@ -62,6 +62,7 @@
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "x509": {

--- a/experimental/generated/elasticsearch/composable/component/user.json
+++ b/experimental/generated/elasticsearch/composable/component/user.json
@@ -62,6 +62,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -124,6 +125,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -200,6 +202,7 @@
             },
             "roles": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "target": {
@@ -256,6 +259,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/vulnerability.json
+++ b/experimental/generated/elasticsearch/composable/component/vulnerability.json
@@ -10,6 +10,7 @@
           "properties": {
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "classification": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -265,6 +265,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -756,6 +757,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -992,6 +994,7 @@
           },
           "header_flags": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "id": {
@@ -1117,6 +1120,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1125,6 +1129,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1144,6 +1149,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1162,6 +1168,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1170,6 +1177,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1187,6 +1195,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1236,6 +1245,7 @@
           },
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code": {
@@ -1316,6 +1326,7 @@
           },
           "type": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "url": {
@@ -1366,6 +1377,7 @@
           },
           "attributes": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code_signature": {
@@ -2048,6 +2060,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2536,6 +2549,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2644,6 +2658,7 @@
             "properties": {
               "annotation": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -2655,6 +2670,7 @@
               },
               "label": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "name": {
@@ -3217,6 +3233,7 @@
           },
           "env_vars": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "executable": {
@@ -4088,10 +4105,12 @@
                     "properties": {
                       "effective": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "permitted": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       }
                     }
@@ -4567,10 +4586,12 @@
                 "properties": {
                   "effective": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "permitted": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -4687,10 +4708,12 @@
         "properties": {
           "hash": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "hosts": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "ip": {
@@ -4698,6 +4721,7 @@
           },
           "user": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           }
         }
@@ -4706,6 +4730,7 @@
         "properties": {
           "author": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "category": {
@@ -4915,6 +4940,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4955,6 +4981,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4993,6 +5020,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5049,6 +5077,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5246,6 +5275,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -5262,6 +5292,7 @@
       },
       "tags": {
         "ignore_above": 1024,
+        "synthetic_source_keep": "none",
         "type": "keyword"
       },
       "threat": {
@@ -5313,6 +5344,7 @@
                       },
                       "attributes": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "code_signature": {
@@ -6181,6 +6213,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -6242,6 +6275,7 @@
                   },
                   "attributes": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "code_signature": {
@@ -6798,6 +6832,7 @@
               },
               "id": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "ip": {
@@ -7059,6 +7094,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -7071,6 +7107,7 @@
               },
               "platforms": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "reference": {
@@ -7199,6 +7236,7 @@
               },
               "supported_ciphers": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "x509": {
@@ -7623,6 +7661,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7685,6 +7724,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7761,6 +7801,7 @@
           },
           "roles": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "target": {
@@ -7817,6 +7858,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7963,6 +8005,7 @@
         "properties": {
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "classification": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -7236,7 +7236,6 @@
               },
               "supported_ciphers": {
                 "ignore_above": 1024,
-                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "x509": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -523,6 +523,7 @@
               },
               "tag": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -581,6 +581,7 @@ client.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
@@ -1722,6 +1723,7 @@ destination.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 device.id:
   dashed_name: device-id
@@ -2438,6 +2440,7 @@ dns.header_flags:
   normalize:
   - array
   short: Array of DNS header flags.
+  synthetic_source_keep: none
   type: keyword
 dns.id:
   dashed_name: dns-id
@@ -2775,6 +2778,7 @@ email.bcc.address:
   normalize:
   - array
   short: Email address of BCC recipient
+  synthetic_source_keep: none
   type: keyword
 email.cc.address:
   dashed_name: email-cc-address
@@ -2787,6 +2791,7 @@ email.cc.address:
   normalize:
   - array
   short: Email address of CC recipient
+  synthetic_source_keep: none
   type: keyword
 email.content_type:
   dashed_name: email-content-type
@@ -2835,6 +2840,7 @@ email.from.address:
   normalize:
   - array
   short: The sender's email address.
+  synthetic_source_keep: none
   type: keyword
 email.local_id:
   dashed_name: email-local-id
@@ -2884,6 +2890,7 @@ email.reply_to.address:
   normalize:
   - array
   short: Address replies should be delivered to.
+  synthetic_source_keep: none
   type: keyword
 email.sender.address:
   dashed_name: email-sender-address
@@ -2895,6 +2902,7 @@ email.sender.address:
   name: sender.address
   normalize: []
   short: Address of the message sender.
+  synthetic_source_keep: none
   type: keyword
 email.subject:
   dashed_name: email-subject
@@ -2922,6 +2930,7 @@ email.to.address:
   normalize:
   - array
   short: Email address of recipient
+  synthetic_source_keep: none
   type: keyword
 email.x_mailer:
   dashed_name: email-x-mailer
@@ -3279,6 +3288,7 @@ event.category:
   normalize:
   - array
   short: Event category. The second categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.code:
   dashed_name: event-code
@@ -3840,6 +3850,7 @@ event.type:
   normalize:
   - array
   short: Event type. The third categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.url:
   dashed_name: event-url
@@ -3990,6 +4001,7 @@ file.attributes:
   - relation: match
     stability: experimental
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 file.code_signature.digest_algorithm:
   dashed_name: file-code-signature-digest-algorithm
@@ -6059,6 +6071,7 @@ host.ip:
   - relation: match
     stability: experimental
   short: Host ip addresses.
+  synthetic_source_keep: none
   type: ip
 host.mac:
   dashed_name: host-mac
@@ -6079,6 +6092,7 @@ host.mac:
     stability: experimental
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
+  synthetic_source_keep: none
   type: keyword
 host.name:
   dashed_name: host-name
@@ -7437,6 +7451,7 @@ observer.ip:
   normalize:
   - array
   short: IP addresses of the observer.
+  synthetic_source_keep: none
   type: ip
 observer.mac:
   dashed_name: observer-mac
@@ -7454,6 +7469,7 @@ observer.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
+  synthetic_source_keep: none
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -7716,6 +7732,7 @@ orchestrator.resource.annotation:
   normalize:
   - array
   short: The list of annotations added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.id:
   dashed_name: orchestrator-resource-id
@@ -7738,6 +7755,7 @@ orchestrator.resource.ip:
   normalize:
   - array
   short: IP address assigned to the resource associated with the event being observed.
+  synthetic_source_keep: none
   type: ip
 orchestrator.resource.label:
   dashed_name: orchestrator-resource-label
@@ -7750,6 +7768,7 @@ orchestrator.resource.label:
   normalize:
   - array
   short: The list of labels added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
@@ -9249,6 +9268,7 @@ process.env_vars:
   normalize:
   - array
   short: Array of environment variable bindings.
+  synthetic_source_keep: none
   type: keyword
 process.executable:
   dashed_name: process-executable
@@ -11715,6 +11735,7 @@ process.parent.thread.capabilities.effective:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.capabilities.permitted:
   dashed_name: process-parent-thread-capabilities-permitted
@@ -11730,6 +11751,7 @@ process.parent.thread.capabilities.permitted:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
@@ -12941,6 +12963,7 @@ process.thread.capabilities.effective:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.thread.capabilities.permitted:
   dashed_name: process-thread-capabilities-permitted
@@ -12955,6 +12978,7 @@ process.thread.capabilities.permitted:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.thread.id:
   dashed_name: process-thread-id
@@ -13246,6 +13270,7 @@ related.hash:
   otel:
   - relation: na
   short: All the hashes seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.hosts:
   dashed_name: related-hosts
@@ -13260,6 +13285,7 @@ related.hosts:
   otel:
   - relation: na
   short: All the host identifiers seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.ip:
   dashed_name: related-ip
@@ -13272,6 +13298,7 @@ related.ip:
   otel:
   - relation: na
   short: All of the IPs seen on your event.
+  synthetic_source_keep: none
   type: ip
 related.user:
   dashed_name: related-user
@@ -13285,6 +13312,7 @@ related.user:
   otel:
   - relation: na
   short: All the user names or other user identifiers seen on the event.
+  synthetic_source_keep: none
   type: keyword
 rule.author:
   dashed_name: rule-author
@@ -13298,6 +13326,7 @@ rule.author:
   normalize:
   - array
   short: Rule author
+  synthetic_source_keep: none
   type: keyword
 rule.category:
   dashed_name: rule-category
@@ -13874,6 +13903,7 @@ server.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 service.address:
   dashed_name: service-address
@@ -14033,6 +14063,7 @@ service.node.roles:
   normalize:
   - array
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -14189,6 +14220,7 @@ service.origin.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -14398,6 +14430,7 @@ service.target.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.target.state:
   dashed_name: service-target-state
@@ -14941,6 +14974,7 @@ source.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 span.id:
   dashed_name: span-id
@@ -14971,6 +15005,7 @@ tags:
   normalize:
   - array
   short: List of keywords used to tag each event.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments:
   dashed_name: threat-enrichments
@@ -14982,6 +15017,7 @@ threat.enrichments:
   normalize:
   - array
   short: List of objects containing indicators enriching the event.
+  synthetic_source_keep: none
   type: nested
 threat.enrichments.indicator:
   dashed_name: threat-enrichments-indicator
@@ -15090,6 +15126,7 @@ threat.enrichments.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -17687,6 +17724,7 @@ threat.group.alias:
   normalize:
   - array
   short: Alias of the group.
+  synthetic_source_keep: none
   type: keyword
 threat.group.id:
   dashed_name: threat-group-id
@@ -17825,6 +17863,7 @@ threat.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -19522,6 +19561,7 @@ threat.indicator.id:
   normalize:
   - array
   short: ID of the indicator
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
@@ -20311,6 +20351,7 @@ threat.software.alias:
   normalize:
   - array
   short: Alias of the software
+  synthetic_source_keep: none
   type: keyword
 threat.software.id:
   dashed_name: threat-software-id
@@ -20362,6 +20403,7 @@ threat.software.platforms:
   normalize:
   - array
   short: Platforms of the software.
+  synthetic_source_keep: none
   type: keyword
 threat.software.reference:
   dashed_name: threat-software-reference
@@ -20718,6 +20760,7 @@ tls.client.supported_ciphers:
   - relation: match
     stability: experimental
   short: Array of ciphers offered by the client during the client hello.
+  synthetic_source_keep: none
   type: keyword
 tls.client.x509.alternative_names:
   dashed_name: tls-client-x509-alternative-names
@@ -21968,6 +22011,7 @@ user.changes.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.domain:
   dashed_name: user-domain
@@ -22111,6 +22155,7 @@ user.effective.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.email:
   dashed_name: user-email
@@ -22321,6 +22366,7 @@ user.roles:
   - relation: match
     stability: experimental
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.target.domain:
   dashed_name: user-target-domain
@@ -22452,6 +22498,7 @@ user.target.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user_agent.device.name:
   dashed_name: user-agent-device-name
@@ -22820,6 +22867,7 @@ vulnerability.category:
   normalize:
   - array
   short: Category of a vulnerability.
+  synthetic_source_keep: none
   type: keyword
 vulnerability.classification:
   dashed_name: vulnerability-classification

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -20760,7 +20760,6 @@ tls.client.supported_ciphers:
   - relation: match
     stability: experimental
   short: Array of ciphers offered by the client during the client hello.
-  synthetic_source_keep: none
   type: keyword
 tls.client.x509.alternative_names:
   dashed_name: tls-client-x509-alternative-names

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1118,6 +1118,7 @@ container.image.tag:
     relation: equivalent
     stability: experimental
   short: Container image tags.
+  synthetic_source_keep: none
   type: keyword
 container.labels:
   dashed_name: container-labels

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1511,6 +1511,7 @@ container:
         relation: equivalent
         stability: experimental
       short: Container image tags.
+      synthetic_source_keep: none
       type: keyword
     container.labels:
       dashed_name: container-labels

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -23569,7 +23569,6 @@ tls:
       - relation: match
         stability: experimental
       short: Array of ciphers offered by the client during the client hello.
-      synthetic_source_keep: none
       type: keyword
     tls.client.x509.alternative_names:
       dashed_name: tls-client-x509-alternative-names

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -253,6 +253,7 @@ base:
       normalize:
       - array
       short: List of keywords used to tag each event.
+      synthetic_source_keep: none
       type: keyword
   group: 1
   name: base
@@ -746,6 +747,7 @@ client:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: client
@@ -2158,6 +2160,7 @@ destination:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: destination
@@ -2955,6 +2958,7 @@ dns:
       normalize:
       - array
       short: Array of DNS header flags.
+      synthetic_source_keep: none
       type: keyword
     dns.id:
       dashed_name: dns-id
@@ -3742,6 +3746,7 @@ email:
       normalize:
       - array
       short: Email address of BCC recipient
+      synthetic_source_keep: none
       type: keyword
     email.cc.address:
       dashed_name: email-cc-address
@@ -3754,6 +3759,7 @@ email:
       normalize:
       - array
       short: Email address of CC recipient
+      synthetic_source_keep: none
       type: keyword
     email.content_type:
       dashed_name: email-content-type
@@ -3803,6 +3809,7 @@ email:
       normalize:
       - array
       short: The sender's email address.
+      synthetic_source_keep: none
       type: keyword
     email.local_id:
       dashed_name: email-local-id
@@ -3852,6 +3859,7 @@ email:
       normalize:
       - array
       short: Address replies should be delivered to.
+      synthetic_source_keep: none
       type: keyword
     email.sender.address:
       dashed_name: email-sender-address
@@ -3863,6 +3871,7 @@ email:
       name: sender.address
       normalize: []
       short: Address of the message sender.
+      synthetic_source_keep: none
       type: keyword
     email.subject:
       dashed_name: email-subject
@@ -3890,6 +3899,7 @@ email:
       normalize:
       - array
       short: Email address of recipient
+      synthetic_source_keep: none
       type: keyword
     email.x_mailer:
       dashed_name: email-x-mailer
@@ -4288,6 +4298,7 @@ event:
       normalize:
       - array
       short: Event category. The second categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.code:
       dashed_name: event-code
@@ -4861,6 +4872,7 @@ event:
       normalize:
       - array
       short: Event type. The third categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.url:
       dashed_name: event-url
@@ -5037,6 +5049,7 @@ file:
       - relation: match
         stability: experimental
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     file.code_signature.digest_algorithm:
       dashed_name: file-code-signature-digest-algorithm
@@ -7514,6 +7527,7 @@ host:
       - relation: match
         stability: experimental
       short: Host ip addresses.
+      synthetic_source_keep: none
       type: ip
     host.mac:
       dashed_name: host-mac
@@ -7535,6 +7549,7 @@ host:
         stability: experimental
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
+      synthetic_source_keep: none
       type: keyword
     host.name:
       dashed_name: host-name
@@ -9204,6 +9219,7 @@ observer:
       normalize:
       - array
       short: IP addresses of the observer.
+      synthetic_source_keep: none
       type: ip
     observer.mac:
       dashed_name: observer-mac
@@ -9222,6 +9238,7 @@ observer:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
+      synthetic_source_keep: none
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -9521,6 +9538,7 @@ orchestrator:
       normalize:
       - array
       short: The list of annotations added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.id:
       dashed_name: orchestrator-resource-id
@@ -9544,6 +9562,7 @@ orchestrator:
       normalize:
       - array
       short: IP address assigned to the resource associated with the event being observed.
+      synthetic_source_keep: none
       type: ip
     orchestrator.resource.label:
       dashed_name: orchestrator-resource-label
@@ -9556,6 +9575,7 @@ orchestrator:
       normalize:
       - array
       short: The list of labels added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
@@ -11516,6 +11536,7 @@ process:
       normalize:
       - array
       short: Array of environment variable bindings.
+      synthetic_source_keep: none
       type: keyword
     process.executable:
       dashed_name: process-executable
@@ -13989,6 +14010,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.capabilities.permitted:
       dashed_name: process-parent-thread-capabilities-permitted
@@ -14004,6 +14026,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
@@ -15216,6 +15239,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.thread.capabilities.permitted:
       dashed_name: process-thread-capabilities-permitted
@@ -15230,6 +15254,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.thread.id:
       dashed_name: process-thread-id
@@ -15745,6 +15770,7 @@ related:
       otel:
       - relation: na
       short: All the hashes seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.hosts:
       dashed_name: related-hosts
@@ -15759,6 +15785,7 @@ related:
       otel:
       - relation: na
       short: All the host identifiers seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.ip:
       dashed_name: related-ip
@@ -15771,6 +15798,7 @@ related:
       otel:
       - relation: na
       short: All of the IPs seen on your event.
+      synthetic_source_keep: none
       type: ip
     related.user:
       dashed_name: related-user
@@ -15784,6 +15812,7 @@ related:
       otel:
       - relation: na
       short: All the user names or other user identifiers seen on the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: related
@@ -15906,6 +15935,7 @@ rule:
       normalize:
       - array
       short: Rule author
+      synthetic_source_keep: none
       type: keyword
     rule.category:
       dashed_name: rule-category
@@ -16509,6 +16539,7 @@ server:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: server
@@ -16696,6 +16727,7 @@ service:
       normalize:
       - array
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -16854,6 +16886,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -17065,6 +17098,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.target.state:
       dashed_name: service-target-state
@@ -17664,6 +17698,7 @@ source:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: source
@@ -17711,6 +17746,7 @@ threat:
       normalize:
       - array
       short: List of objects containing indicators enriching the event.
+      synthetic_source_keep: none
       type: nested
     threat.enrichments.indicator:
       dashed_name: threat-enrichments-indicator
@@ -17819,6 +17855,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.enrichments.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -20424,6 +20461,7 @@ threat:
       normalize:
       - array
       short: Alias of the group.
+      synthetic_source_keep: none
       type: keyword
     threat.group.id:
       dashed_name: threat-group-id
@@ -20562,6 +20600,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -22262,6 +22301,7 @@ threat:
       normalize:
       - array
       short: ID of the indicator
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
@@ -23056,6 +23096,7 @@ threat:
       normalize:
       - array
       short: Alias of the software
+      synthetic_source_keep: none
       type: keyword
     threat.software.id:
       dashed_name: threat-software-id
@@ -23107,6 +23148,7 @@ threat:
       normalize:
       - array
       short: Platforms of the software.
+      synthetic_source_keep: none
       type: keyword
     threat.software.reference:
       dashed_name: threat-software-reference
@@ -23527,6 +23569,7 @@ tls:
       - relation: match
         stability: experimental
       short: Array of ciphers offered by the client during the client hello.
+      synthetic_source_keep: none
       type: keyword
     tls.client.x509.alternative_names:
       dashed_name: tls-client-x509-alternative-names
@@ -24861,6 +24904,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.domain:
       dashed_name: user-domain
@@ -25004,6 +25048,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.email:
       dashed_name: user-email
@@ -25214,6 +25259,7 @@ user:
       - relation: match
         stability: experimental
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.target.domain:
       dashed_name: user-target-domain
@@ -25345,6 +25391,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: user
@@ -25878,6 +25925,7 @@ vulnerability:
       normalize:
       - array
       short: Category of a vulnerability.
+      synthetic_source_keep: none
       type: keyword
     vulnerability.classification:
       dashed_name: vulnerability-classification

--- a/generated/elasticsearch/composable/component/base.json
+++ b/generated/elasticsearch/composable/component/base.json
@@ -17,6 +17,7 @@
         },
         "tags": {
           "ignore_above": 1024,
+          "synthetic_source_keep": "none",
           "type": "keyword"
         }
       }

--- a/generated/elasticsearch/composable/component/client.json
+++ b/generated/elasticsearch/composable/component/client.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/container.json
+++ b/generated/elasticsearch/composable/component/container.json
@@ -54,6 +54,7 @@
                 },
                 "tag": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/destination.json
+++ b/generated/elasticsearch/composable/component/destination.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/dns.json
+++ b/generated/elasticsearch/composable/component/dns.json
@@ -34,6 +34,7 @@
             },
             "header_flags": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "id": {

--- a/generated/elasticsearch/composable/component/email.json
+++ b/generated/elasticsearch/composable/component/email.json
@@ -72,6 +72,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -80,6 +81,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -99,6 +101,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -117,6 +120,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -125,6 +129,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -142,6 +147,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/event.json
+++ b/generated/elasticsearch/composable/component/event.json
@@ -18,6 +18,7 @@
             },
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code": {
@@ -98,6 +99,7 @@
             },
             "type": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "url": {

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -13,6 +13,7 @@
             },
             "attributes": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code_signature": {

--- a/generated/elasticsearch/composable/component/host.json
+++ b/generated/elasticsearch/composable/component/host.json
@@ -110,6 +110,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/generated/elasticsearch/composable/component/observer.json
+++ b/generated/elasticsearch/composable/component/observer.json
@@ -138,6 +138,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/generated/elasticsearch/composable/component/orchestrator.json
+++ b/generated/elasticsearch/composable/component/orchestrator.json
@@ -44,6 +44,7 @@
               "properties": {
                 "annotation": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -55,6 +56,7 @@
                 },
                 "label": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "name": {

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -471,6 +471,7 @@
             },
             "env_vars": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "executable": {
@@ -1342,10 +1343,12 @@
                       "properties": {
                         "effective": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "permitted": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         }
                       }
@@ -1821,10 +1824,12 @@
                   "properties": {
                     "effective": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "permitted": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/generated/elasticsearch/composable/component/related.json
+++ b/generated/elasticsearch/composable/component/related.json
@@ -10,10 +10,12 @@
           "properties": {
             "hash": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "hosts": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "ip": {
@@ -21,6 +23,7 @@
             },
             "user": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             }
           }

--- a/generated/elasticsearch/composable/component/rule.json
+++ b/generated/elasticsearch/composable/component/rule.json
@@ -10,6 +10,7 @@
           "properties": {
             "author": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "category": {

--- a/generated/elasticsearch/composable/component/server.json
+++ b/generated/elasticsearch/composable/component/server.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/service.json
+++ b/generated/elasticsearch/composable/component/service.json
@@ -40,6 +40,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -78,6 +79,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }
@@ -134,6 +136,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/generated/elasticsearch/composable/component/source.json
+++ b/generated/elasticsearch/composable/component/source.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -55,6 +55,7 @@
                         },
                         "attributes": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "code_signature": {
@@ -923,6 +924,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -984,6 +986,7 @@
                     },
                     "attributes": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "code_signature": {
@@ -1540,6 +1543,7 @@
                 },
                 "id": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "ip": {
@@ -1801,6 +1805,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -1813,6 +1818,7 @@
                 },
                 "platforms": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "reference": {

--- a/generated/elasticsearch/composable/component/tls.json
+++ b/generated/elasticsearch/composable/component/tls.json
@@ -62,7 +62,6 @@
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
-                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "x509": {

--- a/generated/elasticsearch/composable/component/tls.json
+++ b/generated/elasticsearch/composable/component/tls.json
@@ -62,6 +62,7 @@
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "x509": {

--- a/generated/elasticsearch/composable/component/user.json
+++ b/generated/elasticsearch/composable/component/user.json
@@ -62,6 +62,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -124,6 +125,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -200,6 +202,7 @@
             },
             "roles": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "target": {
@@ -256,6 +259,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/vulnerability.json
+++ b/generated/elasticsearch/composable/component/vulnerability.json
@@ -10,6 +10,7 @@
           "properties": {
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "classification": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -7194,7 +7194,6 @@
               },
               "supported_ciphers": {
                 "ignore_above": 1024,
-                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "x509": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -481,6 +481,7 @@
               },
               "tag": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -223,6 +223,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -714,6 +715,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -950,6 +952,7 @@
           },
           "header_flags": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "id": {
@@ -1075,6 +1078,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1083,6 +1087,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1102,6 +1107,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1120,6 +1126,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1128,6 +1135,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1145,6 +1153,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1194,6 +1203,7 @@
           },
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code": {
@@ -1274,6 +1284,7 @@
           },
           "type": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "url": {
@@ -1324,6 +1335,7 @@
           },
           "attributes": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code_signature": {
@@ -2006,6 +2018,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2494,6 +2507,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2602,6 +2616,7 @@
             "properties": {
               "annotation": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -2613,6 +2628,7 @@
               },
               "label": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "name": {
@@ -3175,6 +3191,7 @@
           },
           "env_vars": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "executable": {
@@ -4046,10 +4063,12 @@
                     "properties": {
                       "effective": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "permitted": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       }
                     }
@@ -4525,10 +4544,12 @@
                 "properties": {
                   "effective": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "permitted": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -4645,10 +4666,12 @@
         "properties": {
           "hash": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "hosts": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "ip": {
@@ -4656,6 +4679,7 @@
           },
           "user": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           }
         }
@@ -4664,6 +4688,7 @@
         "properties": {
           "author": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "category": {
@@ -4873,6 +4898,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4913,6 +4939,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4951,6 +4978,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5007,6 +5035,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5204,6 +5233,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -5220,6 +5250,7 @@
       },
       "tags": {
         "ignore_above": 1024,
+        "synthetic_source_keep": "none",
         "type": "keyword"
       },
       "threat": {
@@ -5271,6 +5302,7 @@
                       },
                       "attributes": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "code_signature": {
@@ -6139,6 +6171,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -6200,6 +6233,7 @@
                   },
                   "attributes": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "code_signature": {
@@ -6756,6 +6790,7 @@
               },
               "id": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "ip": {
@@ -7017,6 +7052,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -7029,6 +7065,7 @@
               },
               "platforms": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "reference": {
@@ -7157,6 +7194,7 @@
               },
               "supported_ciphers": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "x509": {
@@ -7581,6 +7619,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7643,6 +7682,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7719,6 +7759,7 @@
           },
           "roles": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "target": {
@@ -7775,6 +7816,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7921,6 +7963,7 @@
         "properties": {
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "classification": {

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -64,6 +64,7 @@
         List of keywords used to tag each event.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: labels
       level: core

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -78,6 +78,7 @@
         Container image tags.
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - attribute: container.image.tags
           relation: equivalent

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -79,6 +79,7 @@
       example: "[\"RD\", \"RA\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: response_code
       level: extended

--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -79,6 +79,7 @@
       example: "bcc.user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: cc.address
       level: extended
@@ -89,6 +90,7 @@
       example: "cc.user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: content_type
       level: extended
@@ -125,6 +127,7 @@
       example: "sender@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: local_id
       level: extended
@@ -163,6 +166,7 @@
       example: "reply.here@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: sender.address
       level: extended
@@ -171,6 +175,7 @@
       description: >
         Per RFC 5322, specifies the address responsible for the actual transmission of
         the message.
+      synthetic_source_keep: "none"
 
     - name: subject
       level: extended
@@ -192,6 +197,7 @@
       example: "user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: x_mailer
       level: extended

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -173,6 +173,7 @@
       example: authentication
       normalize:
         - array
+      synthetic_source_keep: "none"
       allowed_values:
         - name: api
           description: >
@@ -466,6 +467,7 @@
         that fall in multiple event types.
       normalize:
         - array
+      synthetic_source_keep: "none"
       allowed_values:
         - name: access
           description: >

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -54,6 +54,7 @@
       example: '["readonly", "system"]'
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: match
     - name: directory

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -70,6 +70,7 @@
         Host ip addresses.
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: match
 
@@ -88,6 +89,7 @@
         hyphen.
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: match
 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -48,6 +48,7 @@
         hyphen.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: ip
       level: core
@@ -56,6 +57,7 @@
         IP addresses of the observer.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: hostname
       level: core

--- a/schemas/orchestrator.yml
+++ b/schemas/orchestrator.yml
@@ -77,6 +77,7 @@
         The list of annotations added to the resource.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.label
       level: extended
@@ -86,6 +87,7 @@
         The list of labels added to the resource.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.name
       level: extended
@@ -119,6 +121,7 @@
         In the case of a Kubernetes Pod, this array would contain only one element: the IP of the Pod (as opposed to the Node on which the Pod is running).
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.id
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -256,6 +256,7 @@
       example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: thread.capabilities.effective
       level: extended
@@ -268,6 +269,7 @@
       example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: start
       level: extended
@@ -366,6 +368,7 @@
       example: "[\"PATH=/usr/local/bin:/usr/bin\", \"USER=ubuntu\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: entry_meta.type
       level: extended

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -40,6 +40,7 @@
         All of the IPs seen on your event.
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: na
 
@@ -51,6 +52,7 @@
 
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: na
 
@@ -64,6 +66,7 @@
         the hash algorithm is (and therefore which key name to search).
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: na
 
@@ -76,5 +79,6 @@
         identifiers include FQDNs, domain names, workstation names, or aliases.
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: na

--- a/schemas/rule.yml
+++ b/schemas/rule.yml
@@ -107,6 +107,7 @@
       example: "[\"Star-Lord\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: license
       level: extended

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -147,6 +147,7 @@
       example: "[\"ui\", \"background_tasks\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
       short: Roles of the service node.
       description: >
         Roles of a service node.

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -39,6 +39,7 @@
         that association/enrichment.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: enrichments.indicator
       level: extended
@@ -311,6 +312,7 @@
       example: '[ "Magecart Group 6" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: group.id
       level: extended
@@ -527,6 +529,7 @@
       example: "[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.id
       level: extended
@@ -560,6 +563,7 @@
       example: '[ "X-Agent" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.platforms
       level: extended
@@ -583,6 +587,7 @@
       example: '[ "Windows" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.reference
       level: extended

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -104,7 +104,6 @@
       example: "[\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\", \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\", \"...\"]"
       normalize:
         - array
-      synthetic_source_keep: "none"
       otel:
         - relation: match
 

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -104,6 +104,7 @@
       example: "[\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\", \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\", \"...\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
       otel:
         - relation: match
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -146,6 +146,7 @@
       type: keyword
       normalize:
         - array
+      synthetic_source_keep: "none"
       description: >
         Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -125,6 +125,7 @@
       example: '["Firewall"]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: description
       level: extended

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -181,7 +181,7 @@ def entry_for(field: Field) -> Dict:
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['index', 'doc_values'])
 
         if field['type'] == 'keyword' or field['type'] == 'flattened':
-            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above'])
+            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above', 'synthetic_source_keep'])
         elif field['type'] == 'constant_keyword':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['value'])
         elif field['type'] == 'text':


### PR DESCRIPTION
Add support for synthetic_source_keep mapping in generated elasticsearch component files, and add this mapping field to all ECS fields that represent sets.

synthetic_source_keep = none indicates that field is an unordered set, and helps improve storage efficiency with Elasticsearch logsdb index mode.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? y
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? y
