### PR TITLE
Fix link rendering issues and usage of http in links

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,7 +14,7 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
-* Fix link rendering issues and usage of http in links. #1
+* Fix link rendering issues and usage of http in links. #2423
 
 #### Added
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Fix link rendering issues and usage of http in links. #1
+
 #### Added
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -496,7 +496,7 @@ a| The highest registered client domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -532,7 +532,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -1596,7 +1596,7 @@ a| The highest registered destination domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -1632,7 +1632,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -2125,7 +2125,7 @@ a| The highest registered domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -2161,7 +2161,7 @@ example: `www`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -2391,7 +2391,7 @@ Note: this field should contain an array of values.
 
 a| A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
 
 type: keyword
 
@@ -6228,7 +6228,7 @@ beta::[ These fields are in beta and are subject to change.]
 
 a| A hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
 
 type: keyword
 
@@ -7897,7 +7897,7 @@ example: `6.3.9600.17415`
 
 a| A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
 
 type: keyword
 
@@ -9934,7 +9934,7 @@ a| The highest registered server domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -9970,7 +9970,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -10505,7 +10505,7 @@ a| The highest registered source domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -10541,7 +10541,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -12804,7 +12804,7 @@ a| The highest registered url domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -12864,7 +12864,7 @@ image:https://img.shields.io/badge/OpenTelemetry-4a5ca6?style=flat&logo=opentele
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -13663,7 +13663,7 @@ The vulnerability fields describe information about a vulnerability that is rele
 [[field-vulnerability-category]]
 <<field-vulnerability-category, vulnerability.category>>
 
-a| The type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys vulnerability categories])
+a| The type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
 This field must be an array.
 
@@ -13700,7 +13700,7 @@ example: `CVSS`
 [[field-vulnerability-description]]
 <<field-vulnerability-description, vulnerability.description>>
 
-a| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+a| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
 
 type: keyword
 
@@ -13738,7 +13738,7 @@ example: `CVE`
 [[field-vulnerability-id]]
 <<field-vulnerability-id, vulnerability.id>>
 
-a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
+a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
 
 type: keyword
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2391,7 +2391,7 @@ Note: this field should contain an array of values.
 
 a| A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma)
 
 type: keyword
 
@@ -6228,7 +6228,7 @@ beta::[ These fields are in beta and are subject to change.]
 
 a| A hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 
@@ -7897,7 +7897,7 @@ example: `6.3.9600.17415`
 
 a| A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma.
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2391,7 +2391,7 @@ Note: this field should contain an array of values.
 
 a| A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma)
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2585,7 +2585,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -4916,7 +4916,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -6241,7 +6241,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -9330,7 +9330,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -10952,7 +10952,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -362,7 +362,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -388,7 +388,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1080,7 +1080,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -1106,7 +1106,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1444,7 +1444,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1683,7 +1683,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: question.subdomain
@@ -1704,7 +1704,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: question.type
@@ -2585,7 +2585,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2891,7 +2891,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3076,7 +3076,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4916,7 +4916,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5965,7 +5965,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6241,7 +6241,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6612,7 +6612,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6767,7 +6767,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7139,7 +7139,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -8252,7 +8252,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8278,7 +8278,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -8980,7 +8980,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -9006,7 +9006,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -9330,7 +9330,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9718,7 +9718,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10390,7 +10390,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -10426,7 +10426,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -10952,7 +10952,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11340,7 +11340,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports
@@ -12023,7 +12023,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -12059,7 +12059,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -13085,7 +13085,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: scheme
@@ -13119,7 +13119,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: username
@@ -13727,8 +13727,7 @@
       ignore_above: 1024
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -13749,8 +13748,7 @@
       - name: text
         type: match_only_text
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       default_field: false
     - name: enumeration
@@ -13767,8 +13765,7 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1444,7 +1444,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -2585,7 +2585,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2891,7 +2891,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3076,7 +3076,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4916,7 +4916,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5965,7 +5965,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6241,7 +6241,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6612,7 +6612,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6767,7 +6767,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7139,7 +7139,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -9330,7 +9330,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9718,7 +9718,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10952,7 +10952,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11340,7 +11340,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4332,7 +4332,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -8297,7 +8297,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -10478,7 +10478,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -15427,7 +15427,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18162,7 +18162,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -475,7 +475,7 @@ client.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: client.registered_domain
@@ -510,7 +510,7 @@ client.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: client.top_level_domain
@@ -1615,7 +1615,7 @@ destination.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: destination.registered_domain
@@ -1650,7 +1650,7 @@ destination.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: destination.top_level_domain
@@ -2176,7 +2176,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -2569,7 +2569,7 @@ dns.question.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: dns.question.registered_domain
@@ -2600,7 +2600,7 @@ dns.question.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: dns.question.top_level_domain
@@ -4332,7 +4332,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4894,7 +4894,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -5228,7 +5228,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -8297,7 +8297,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -10019,7 +10019,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10478,7 +10478,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -11116,7 +11116,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -11380,7 +11380,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -12007,7 +12007,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -13767,7 +13767,7 @@ server.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: server.registered_domain
@@ -13802,7 +13802,7 @@ server.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: server.top_level_domain
@@ -14834,7 +14834,7 @@ source.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: source.registered_domain
@@ -14869,7 +14869,7 @@ source.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: source.top_level_domain
@@ -15427,7 +15427,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -16102,7 +16102,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -17237,7 +17237,7 @@ threat.enrichments.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.enrichments.indicator.url.registered_domain
@@ -17288,7 +17288,7 @@ threat.enrichments.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -18162,7 +18162,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18837,7 +18837,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -19988,7 +19988,7 @@ threat.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.indicator.url.registered_domain
@@ -20039,7 +20039,7 @@ threat.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.indicator.url.top_level_domain
@@ -21826,7 +21826,7 @@ url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: url.registered_domain
@@ -21883,7 +21883,7 @@ url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: url.top_level_domain
@@ -22876,8 +22876,7 @@ vulnerability.category:
   dashed_name: vulnerability-category
   description: 'The type of system or architecture that the vulnerability affects.
     These may be platform-specific (for example, Debian or SUSE) or general (for example,
-    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-    vulnerability categories])
+    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
     This field must be an array.'
   example: '["Firewall"]'
@@ -22904,8 +22903,7 @@ vulnerability.classification:
 vulnerability.description:
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
-    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-    Vulnerabilities and Exposure CVE description])
+    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
   example: In macOS before 2.12.6, there is a vulnerability in the RPC...
   flat_name: vulnerability.description
   ignore_above: 1024
@@ -22933,8 +22931,7 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
-    Exposure CVE ID])
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2176,7 +2176,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -4332,7 +4332,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4894,7 +4894,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -5228,7 +5228,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -8297,7 +8297,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -10019,7 +10019,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10478,7 +10478,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -11116,7 +11116,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -11380,7 +11380,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -12007,7 +12007,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -15427,7 +15427,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -16102,7 +16102,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -18162,7 +18162,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18837,7 +18837,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2674,7 +2674,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3294,7 +3294,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5390,7 +5390,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5953,7 +5953,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6288,7 +6288,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8480,7 +8480,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -10078,7 +10078,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10574,7 +10574,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12300,7 +12300,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12760,7 +12760,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -13399,7 +13399,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13664,7 +13664,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -14292,7 +14292,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -18167,7 +18167,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18843,7 +18843,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -20910,7 +20910,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21586,7 +21586,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -651,7 +651,7 @@ client:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: client.registered_domain
@@ -686,7 +686,7 @@ client:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: client.top_level_domain
@@ -2062,7 +2062,7 @@ destination:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: destination.registered_domain
@@ -2097,7 +2097,7 @@ destination:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: destination.top_level_domain
@@ -2674,7 +2674,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3098,7 +3098,7 @@ dns:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: dns.question.registered_domain
@@ -3129,7 +3129,7 @@ dns:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: dns.question.top_level_domain
@@ -3294,7 +3294,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5390,7 +5390,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5953,7 +5953,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6288,7 +6288,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8480,7 +8480,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -10078,7 +10078,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10574,7 +10574,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12300,7 +12300,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12760,7 +12760,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -13399,7 +13399,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13664,7 +13664,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -14292,7 +14292,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -16413,7 +16413,7 @@ server:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: server.registered_domain
@@ -16448,7 +16448,7 @@ server:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: server.top_level_domain
@@ -17568,7 +17568,7 @@ source:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: source.registered_domain
@@ -17603,7 +17603,7 @@ source:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: source.top_level_domain
@@ -18167,7 +18167,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18843,7 +18843,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19984,7 +19984,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.enrichments.indicator.url.registered_domain
@@ -20035,7 +20035,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -20910,7 +20910,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21586,7 +21586,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -22743,7 +22743,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.indicator.url.registered_domain
@@ -22794,7 +22794,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.indicator.url.top_level_domain
@@ -24708,7 +24708,7 @@ url:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: url.registered_domain
@@ -24765,7 +24765,7 @@ url:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: url.top_level_domain
@@ -25945,8 +25945,7 @@ vulnerability:
       dashed_name: vulnerability-category
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -25973,8 +25972,7 @@ vulnerability:
     vulnerability.description:
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       flat_name: vulnerability.description
       ignore_above: 1024
@@ -26003,8 +26001,7 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3294,7 +3294,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5390,7 +5390,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -10574,7 +10574,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12760,7 +12760,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -18167,7 +18167,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -20910,7 +20910,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2535,7 +2535,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -4866,7 +4866,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -6191,7 +6191,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -9280,7 +9280,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -10902,7 +10902,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1394,7 +1394,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -2535,7 +2535,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2841,7 +2841,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3026,7 +3026,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4866,7 +4866,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5915,7 +5915,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6191,7 +6191,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6562,7 +6562,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6717,7 +6717,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7089,7 +7089,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -9280,7 +9280,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9668,7 +9668,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10902,7 +10902,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11290,7 +11290,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -312,7 +312,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -338,7 +338,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1030,7 +1030,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -1056,7 +1056,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1394,7 +1394,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1633,7 +1633,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: question.subdomain
@@ -1654,7 +1654,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: question.type
@@ -2535,7 +2535,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2841,7 +2841,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3026,7 +3026,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4866,7 +4866,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5915,7 +5915,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6191,7 +6191,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6562,7 +6562,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6717,7 +6717,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7089,7 +7089,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -8202,7 +8202,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8228,7 +8228,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -8930,7 +8930,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8956,7 +8956,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -9280,7 +9280,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9668,7 +9668,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10340,7 +10340,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -10376,7 +10376,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -10902,7 +10902,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11290,7 +11290,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports
@@ -11973,7 +11973,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -12009,7 +12009,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -13035,7 +13035,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: scheme
@@ -13069,7 +13069,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: username
@@ -13677,8 +13677,7 @@
       ignore_above: 1024
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -13699,8 +13698,7 @@
       - name: text
         type: match_only_text
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       default_field: false
     - name: enumeration
@@ -13717,8 +13715,7 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -406,7 +406,7 @@ client.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: client.registered_domain
@@ -441,7 +441,7 @@ client.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: client.top_level_domain
@@ -1546,7 +1546,7 @@ destination.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: destination.registered_domain
@@ -1581,7 +1581,7 @@ destination.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: destination.top_level_domain
@@ -2107,7 +2107,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -2500,7 +2500,7 @@ dns.question.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: dns.question.registered_domain
@@ -2531,7 +2531,7 @@ dns.question.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: dns.question.top_level_domain
@@ -4263,7 +4263,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4825,7 +4825,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -5159,7 +5159,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -8228,7 +8228,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9950,7 +9950,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10409,7 +10409,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -11047,7 +11047,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -11311,7 +11311,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11938,7 +11938,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -13698,7 +13698,7 @@ server.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: server.registered_domain
@@ -13733,7 +13733,7 @@ server.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: server.top_level_domain
@@ -14765,7 +14765,7 @@ source.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: source.registered_domain
@@ -14800,7 +14800,7 @@ source.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: source.top_level_domain
@@ -15358,7 +15358,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -16033,7 +16033,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -17168,7 +17168,7 @@ threat.enrichments.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.enrichments.indicator.url.registered_domain
@@ -17219,7 +17219,7 @@ threat.enrichments.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -18093,7 +18093,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18768,7 +18768,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma.'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -19919,7 +19919,7 @@ threat.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.indicator.url.registered_domain
@@ -19970,7 +19970,7 @@ threat.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.indicator.url.top_level_domain
@@ -21757,7 +21757,7 @@ url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: url.registered_domain
@@ -21814,7 +21814,7 @@ url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: url.top_level_domain
@@ -22807,8 +22807,7 @@ vulnerability.category:
   dashed_name: vulnerability-category
   description: 'The type of system or architecture that the vulnerability affects.
     These may be platform-specific (for example, Debian or SUSE) or general (for example,
-    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-    vulnerability categories])
+    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
     This field must be an array.'
   example: '["Firewall"]'
@@ -22835,8 +22834,7 @@ vulnerability.classification:
 vulnerability.description:
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
-    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-    Vulnerabilities and Exposure CVE description])
+    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
   example: In macOS before 2.12.6, there is a vulnerability in the RPC...
   flat_name: vulnerability.description
   ignore_above: 1024
@@ -22864,8 +22862,7 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
-    Exposure CVE ID])
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2107,7 +2107,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -4263,7 +4263,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4825,7 +4825,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -5159,7 +5159,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -8228,7 +8228,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9950,7 +9950,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10409,7 +10409,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -11047,7 +11047,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -11311,7 +11311,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11938,7 +11938,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -15358,7 +15358,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -16033,7 +16033,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -18093,7 +18093,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma)'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18768,7 +18768,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma.'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4263,7 +4263,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -8228,7 +8228,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -10409,7 +10409,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -15358,7 +15358,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18093,7 +18093,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available here: https://github.com/elastic/toutoumomoma)'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2594,7 +2594,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3214,7 +3214,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5310,7 +5310,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5873,7 +5873,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6208,7 +6208,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8400,7 +8400,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9998,7 +9998,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10494,7 +10494,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12220,7 +12220,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12680,7 +12680,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -13319,7 +13319,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13584,7 +13584,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -14212,7 +14212,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -18087,7 +18087,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18763,7 +18763,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -20830,7 +20830,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma)'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21506,7 +21506,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -571,7 +571,7 @@ client:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: client.registered_domain
@@ -606,7 +606,7 @@ client:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: client.top_level_domain
@@ -1982,7 +1982,7 @@ destination:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: destination.registered_domain
@@ -2017,7 +2017,7 @@ destination:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: destination.top_level_domain
@@ -2594,7 +2594,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3018,7 +3018,7 @@ dns:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: dns.question.registered_domain
@@ -3049,7 +3049,7 @@ dns:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: dns.question.top_level_domain
@@ -3214,7 +3214,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5310,7 +5310,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5873,7 +5873,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6208,7 +6208,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8400,7 +8400,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9998,7 +9998,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10494,7 +10494,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12220,7 +12220,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12680,7 +12680,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -13319,7 +13319,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13584,7 +13584,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -14212,7 +14212,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -16333,7 +16333,7 @@ server:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: server.registered_domain
@@ -16368,7 +16368,7 @@ server:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: server.top_level_domain
@@ -17488,7 +17488,7 @@ source:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: source.registered_domain
@@ -17523,7 +17523,7 @@ source:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: source.top_level_domain
@@ -18087,7 +18087,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18763,7 +18763,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19904,7 +19904,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.enrichments.indicator.url.registered_domain
@@ -19955,7 +19955,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -20830,7 +20830,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21506,7 +21506,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma.'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -22663,7 +22663,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.indicator.url.registered_domain
@@ -22714,7 +22714,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.indicator.url.top_level_domain
@@ -24628,7 +24628,7 @@ url:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: url.registered_domain
@@ -24685,7 +24685,7 @@ url:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: url.top_level_domain
@@ -25865,8 +25865,7 @@ vulnerability:
       dashed_name: vulnerability-category
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -25893,8 +25892,7 @@ vulnerability:
     vulnerability.description:
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       flat_name: vulnerability.description
       ignore_above: 1024
@@ -25923,8 +25921,7 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3214,7 +3214,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5310,7 +5310,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -10494,7 +10494,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -12680,7 +12680,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -18087,7 +18087,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -20830,7 +20830,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -102,7 +102,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -116,7 +116,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -96,7 +96,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -110,7 +110,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -123,7 +123,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -137,7 +137,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -70,7 +70,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma)
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -70,7 +70,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma.
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -70,7 +70,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.
+        are available here: https://github.com/elastic/toutoumomoma)
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/macho.yml
+++ b/schemas/macho.yml
@@ -41,7 +41,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma.
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/macho.yml
+++ b/schemas/macho.yml
@@ -41,7 +41,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -86,7 +86,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available here: https://github.com/elastic/toutoumomoma.
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -86,7 +86,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma.
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -101,7 +101,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -115,7 +115,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -101,7 +101,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -115,7 +115,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -104,7 +104,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
       otel:
@@ -120,7 +120,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
       otel:

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -118,7 +118,7 @@
         The type of system or architecture that the vulnerability affects. These may be
         platform-specific (for example, Debian or SUSE) or general (for example, Database
         or Firewall).
-        For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys vulnerability categories])
+        For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.
 
@@ -136,7 +136,7 @@
       description: >
         The description of the vulnerability that provides additional context of the
         vulnerability.
-        For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+        For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
 
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
 
@@ -147,7 +147,7 @@
       description: >
         The identification (ID) is the number portion of a vulnerability entry. It
         includes a unique identification number for the vulnerability.
-        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
+        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
 
       example: CVE-2019-00001
 


### PR DESCRIPTION
## Description

- Removed link text markup, causes issues since final rendering of docs can be in either markdown or asciidoc
- Replace http with https in links

## Related Issues

- #2416 