### PR TITLE
Increase url.query ignore_above value to 2083

### DIFF
--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -10372,7 +10372,7 @@
     - name: enrichments.indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -12005,7 +12005,7 @@
     - name: indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -13068,7 +13068,7 @@
     - name: query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -17223,7 +17223,7 @@ threat.enrichments.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.enrichments.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -19974,7 +19974,7 @@ threat.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -21810,7 +21810,7 @@ url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -19970,7 +19970,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.enrichments.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -22729,7 +22729,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -24692,7 +24692,7 @@ url:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -731,7 +731,7 @@
                           "type": "long"
                         },
                         "query": {
-                          "ignore_above": 1024,
+                          "ignore_above": 2083,
                           "type": "keyword"
                         },
                         "registered_domain": {
@@ -1664,7 +1664,7 @@
                       "type": "long"
                     },
                     "query": {
-                      "ignore_above": 1024,
+                      "ignore_above": 2083,
                       "type": "keyword"
                     },
                     "registered_domain": {

--- a/experimental/generated/elasticsearch/composable/component/url.json
+++ b/experimental/generated/elasticsearch/composable/component/url.json
@@ -47,7 +47,7 @@
               "type": "long"
             },
             "query": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             },
             "registered_domain": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -5988,7 +5988,7 @@
                         "type": "long"
                       },
                       "query": {
-                        "ignore_above": 1024,
+                        "ignore_above": 2083,
                         "type": "keyword"
                       },
                       "registered_domain": {
@@ -6921,7 +6921,7 @@
                     "type": "long"
                   },
                   "query": {
-                    "ignore_above": 1024,
+                    "ignore_above": 2083,
                     "type": "keyword"
                   },
                   "registered_domain": {
@@ -7541,7 +7541,7 @@
             "type": "long"
           },
           "query": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           },
           "registered_domain": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -10322,7 +10322,7 @@
     - name: enrichments.indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -11955,7 +11955,7 @@
     - name: indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -13018,7 +13018,7 @@
     - name: query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -17154,7 +17154,7 @@ threat.enrichments.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.enrichments.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -19905,7 +19905,7 @@ threat.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -21741,7 +21741,7 @@ url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -19890,7 +19890,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.enrichments.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -22649,7 +22649,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -24612,7 +24612,7 @@ url:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -731,7 +731,7 @@
                           "type": "long"
                         },
                         "query": {
-                          "ignore_above": 1024,
+                          "ignore_above": 2083,
                           "type": "keyword"
                         },
                         "registered_domain": {
@@ -1664,7 +1664,7 @@
                       "type": "long"
                     },
                     "query": {
-                      "ignore_above": 1024,
+                      "ignore_above": 2083,
                       "type": "keyword"
                     },
                     "registered_domain": {

--- a/generated/elasticsearch/composable/component/url.json
+++ b/generated/elasticsearch/composable/component/url.json
@@ -47,7 +47,7 @@
               "type": "long"
             },
             "query": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             },
             "registered_domain": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -5946,7 +5946,7 @@
                         "type": "long"
                       },
                       "query": {
-                        "ignore_above": 1024,
+                        "ignore_above": 2083,
                         "type": "keyword"
                       },
                       "registered_domain": {
@@ -6879,7 +6879,7 @@
                     "type": "long"
                   },
                   "query": {
-                    "ignore_above": 1024,
+                    "ignore_above": 2083,
                     "type": "keyword"
                   },
                   "registered_domain": {
@@ -7499,7 +7499,7 @@
             "type": "long"
           },
           "query": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           },
           "registered_domain": {

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -173,6 +173,7 @@
         no `?`, there is no query field. If there is a `?` but no query,
         the query field exists with an empty string. The `exists`
         query can be used to differentiate between the two cases.
+      ignore_above: 2083
       otel:
         - relation: match
 


### PR DESCRIPTION
Increasing the url.query ignore_above value will allow indexing longer query values which have been observed.

2083 is used because it will cover the maximum url length for Chrome (2048) and Internet Explorer (2083).

Other browsers and web servers support longer URLs, and there is no absolute URL limit defined in any RFC. So higher values could be possible, supporting Chrome's maximum length will allow compatibility with the most common browser, while not increasing the index size too much.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)?
