### PR TITLE
[Backport 8.x] Add support for synthetic_source_keep = none (#2422)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,9 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Set synthetic_source_keep = none on fields that represent sets. #2422
+
+#### Deprecated
 
 ### Tooling and Artifact Changes
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -628,6 +628,7 @@ client.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
@@ -1131,6 +1132,7 @@ container.image.tag:
   normalize:
   - array
   short: Container image tags.
+  synthetic_source_keep: none
   type: keyword
 container.labels:
   dashed_name: container-labels
@@ -1708,6 +1710,7 @@ destination.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 device.id:
   dashed_name: device-id
@@ -2412,6 +2415,7 @@ dns.header_flags:
   normalize:
   - array
   short: Array of DNS header flags.
+  synthetic_source_keep: none
   type: keyword
 dns.id:
   dashed_name: dns-id
@@ -2744,6 +2748,7 @@ email.bcc.address:
   normalize:
   - array
   short: Email address of BCC recipient
+  synthetic_source_keep: none
   type: keyword
 email.cc.address:
   dashed_name: email-cc-address
@@ -2756,6 +2761,7 @@ email.cc.address:
   normalize:
   - array
   short: Email address of CC recipient
+  synthetic_source_keep: none
   type: keyword
 email.content_type:
   dashed_name: email-content-type
@@ -2804,6 +2810,7 @@ email.from.address:
   normalize:
   - array
   short: The sender's email address.
+  synthetic_source_keep: none
   type: keyword
 email.local_id:
   dashed_name: email-local-id
@@ -2853,6 +2860,7 @@ email.reply_to.address:
   normalize:
   - array
   short: Address replies should be delivered to.
+  synthetic_source_keep: none
   type: keyword
 email.sender.address:
   dashed_name: email-sender-address
@@ -2864,6 +2872,7 @@ email.sender.address:
   name: sender.address
   normalize: []
   short: Address of the message sender.
+  synthetic_source_keep: none
   type: keyword
 email.subject:
   dashed_name: email-subject
@@ -2891,6 +2900,7 @@ email.to.address:
   normalize:
   - array
   short: Email address of recipient
+  synthetic_source_keep: none
   type: keyword
 email.x_mailer:
   dashed_name: email-x-mailer
@@ -3237,6 +3247,7 @@ event.category:
   normalize:
   - array
   short: Event category. The second categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.code:
   dashed_name: event-code
@@ -3798,6 +3809,7 @@ event.type:
   normalize:
   - array
   short: Event type. The third categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.url:
   dashed_name: event-url
@@ -3925,6 +3937,7 @@ file.attributes:
   normalize:
   - array
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 file.code_signature.digest_algorithm:
   dashed_name: file-code-signature-digest-algorithm
@@ -5917,6 +5930,7 @@ host.ip:
   normalize:
   - array
   short: Host ip addresses.
+  synthetic_source_keep: none
   type: ip
 host.mac:
   dashed_name: host-mac
@@ -5934,6 +5948,7 @@ host.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
+  synthetic_source_keep: none
   type: keyword
 host.name:
   dashed_name: host-name
@@ -7194,6 +7209,7 @@ observer.ip:
   normalize:
   - array
   short: IP addresses of the observer.
+  synthetic_source_keep: none
   type: ip
 observer.mac:
   dashed_name: observer-mac
@@ -7211,6 +7227,7 @@ observer.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
+  synthetic_source_keep: none
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -7473,6 +7490,7 @@ orchestrator.resource.annotation:
   normalize:
   - array
   short: The list of annotations added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.id:
   dashed_name: orchestrator-resource-id
@@ -7495,6 +7513,7 @@ orchestrator.resource.ip:
   normalize:
   - array
   short: IP address assigned to the resource associated with the event being observed.
+  synthetic_source_keep: none
   type: ip
 orchestrator.resource.label:
   dashed_name: orchestrator-resource-label
@@ -7507,6 +7526,7 @@ orchestrator.resource.label:
   normalize:
   - array
   short: The list of labels added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
@@ -8996,6 +9016,7 @@ process.env_vars:
   normalize:
   - array
   short: Array of environment variable bindings.
+  synthetic_source_keep: none
   type: keyword
 process.executable:
   dashed_name: process-executable
@@ -11452,6 +11473,7 @@ process.parent.thread.capabilities.effective:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.capabilities.permitted:
   dashed_name: process-parent-thread-capabilities-permitted
@@ -11467,6 +11489,7 @@ process.parent.thread.capabilities.permitted:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
@@ -12660,6 +12683,7 @@ process.thread.capabilities.effective:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.thread.capabilities.permitted:
   dashed_name: process-thread-capabilities-permitted
@@ -12674,6 +12698,7 @@ process.thread.capabilities.permitted:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.thread.id:
   dashed_name: process-thread-id
@@ -12944,6 +12969,7 @@ related.hash:
   normalize:
   - array
   short: All the hashes seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.hosts:
   dashed_name: related-hosts
@@ -12956,6 +12982,7 @@ related.hosts:
   normalize:
   - array
   short: All the host identifiers seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.ip:
   dashed_name: related-ip
@@ -12966,6 +12993,7 @@ related.ip:
   normalize:
   - array
   short: All of the IPs seen on your event.
+  synthetic_source_keep: none
   type: ip
 related.user:
   dashed_name: related-user
@@ -12977,6 +13005,7 @@ related.user:
   normalize:
   - array
   short: All the user names or other user identifiers seen on the event.
+  synthetic_source_keep: none
   type: keyword
 rule.author:
   dashed_name: rule-author
@@ -12990,6 +13019,7 @@ rule.author:
   normalize:
   - array
   short: Rule author
+  synthetic_source_keep: none
   type: keyword
 rule.category:
   dashed_name: rule-category
@@ -13560,6 +13590,7 @@ server.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 service.address:
   dashed_name: service-address
@@ -13708,6 +13739,7 @@ service.node.roles:
   normalize:
   - array
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -13864,6 +13896,7 @@ service.origin.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -14073,6 +14106,7 @@ service.target.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.target.state:
   dashed_name: service-target-state
@@ -14607,6 +14641,7 @@ source.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 span.id:
   dashed_name: span-id
@@ -14633,6 +14668,7 @@ tags:
   normalize:
   - array
   short: List of keywords used to tag each event.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments:
   dashed_name: threat-enrichments
@@ -14644,6 +14680,7 @@ threat.enrichments:
   normalize:
   - array
   short: List of objects containing indicators enriching the event.
+  synthetic_source_keep: none
   type: nested
 threat.enrichments.indicator:
   dashed_name: threat-enrichments-indicator
@@ -14752,6 +14789,7 @@ threat.enrichments.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -17349,6 +17387,7 @@ threat.group.alias:
   normalize:
   - array
   short: Alias of the group.
+  synthetic_source_keep: none
   type: keyword
 threat.group.id:
   dashed_name: threat-group-id
@@ -17487,6 +17526,7 @@ threat.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -19184,6 +19224,7 @@ threat.indicator.id:
   normalize:
   - array
   short: ID of the indicator
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
@@ -19973,6 +20014,7 @@ threat.software.alias:
   normalize:
   - array
   short: Alias of the software
+  synthetic_source_keep: none
   type: keyword
 threat.software.id:
   dashed_name: threat-software-id
@@ -20024,6 +20066,7 @@ threat.software.platforms:
   normalize:
   - array
   short: Platforms of the software.
+  synthetic_source_keep: none
   type: keyword
 threat.software.reference:
   dashed_name: threat-software-reference
@@ -21510,6 +21553,7 @@ user.changes.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.domain:
   dashed_name: user-domain
@@ -21653,6 +21697,7 @@ user.effective.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.email:
   dashed_name: user-email
@@ -21845,6 +21890,7 @@ user.roles:
   normalize:
   - array
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.target.domain:
   dashed_name: user-target-domain
@@ -21976,6 +22022,7 @@ user.target.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user_agent.device.name:
   dashed_name: user-agent-device-name
@@ -22335,6 +22382,7 @@ vulnerability.category:
   normalize:
   - array
   short: Category of a vulnerability.
+  synthetic_source_keep: none
   type: keyword
 vulnerability.classification:
   dashed_name: vulnerability-classification

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -224,6 +224,7 @@ base:
       normalize:
       - array
       short: List of keywords used to tag each event.
+      synthetic_source_keep: none
       type: keyword
   group: 1
   name: base
@@ -791,6 +792,7 @@ client:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: client
@@ -1522,6 +1524,7 @@ container:
       normalize:
       - array
       short: Container image tags.
+      synthetic_source_keep: none
       type: keyword
     container.labels:
       dashed_name: container-labels
@@ -2142,6 +2145,7 @@ destination:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: destination
@@ -2927,6 +2931,7 @@ dns:
       normalize:
       - array
       short: Array of DNS header flags.
+      synthetic_source_keep: none
       type: keyword
     dns.id:
       dashed_name: dns-id
@@ -3709,6 +3714,7 @@ email:
       normalize:
       - array
       short: Email address of BCC recipient
+      synthetic_source_keep: none
       type: keyword
     email.cc.address:
       dashed_name: email-cc-address
@@ -3721,6 +3727,7 @@ email:
       normalize:
       - array
       short: Email address of CC recipient
+      synthetic_source_keep: none
       type: keyword
     email.content_type:
       dashed_name: email-content-type
@@ -3770,6 +3777,7 @@ email:
       normalize:
       - array
       short: The sender's email address.
+      synthetic_source_keep: none
       type: keyword
     email.local_id:
       dashed_name: email-local-id
@@ -3819,6 +3827,7 @@ email:
       normalize:
       - array
       short: Address replies should be delivered to.
+      synthetic_source_keep: none
       type: keyword
     email.sender.address:
       dashed_name: email-sender-address
@@ -3830,6 +3839,7 @@ email:
       name: sender.address
       normalize: []
       short: Address of the message sender.
+      synthetic_source_keep: none
       type: keyword
     email.subject:
       dashed_name: email-subject
@@ -3857,6 +3867,7 @@ email:
       normalize:
       - array
       short: Email address of recipient
+      synthetic_source_keep: none
       type: keyword
     email.x_mailer:
       dashed_name: email-x-mailer
@@ -4244,6 +4255,7 @@ event:
       normalize:
       - array
       short: Event category. The second categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.code:
       dashed_name: event-code
@@ -4817,6 +4829,7 @@ event:
       normalize:
       - array
       short: Event type. The third categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.url:
       dashed_name: event-url
@@ -4970,6 +4983,7 @@ file:
       normalize:
       - array
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     file.code_signature.digest_algorithm:
       dashed_name: file-code-signature-digest-algorithm
@@ -7344,6 +7358,7 @@ host:
       normalize:
       - array
       short: Host ip addresses.
+      synthetic_source_keep: none
       type: ip
     host.mac:
       dashed_name: host-mac
@@ -7362,6 +7377,7 @@ host:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
+      synthetic_source_keep: none
       type: keyword
     host.name:
       dashed_name: host-name
@@ -8946,6 +8962,7 @@ observer:
       normalize:
       - array
       short: IP addresses of the observer.
+      synthetic_source_keep: none
       type: ip
     observer.mac:
       dashed_name: observer-mac
@@ -8964,6 +8981,7 @@ observer:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
+      synthetic_source_keep: none
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -9263,6 +9281,7 @@ orchestrator:
       normalize:
       - array
       short: The list of annotations added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.id:
       dashed_name: orchestrator-resource-id
@@ -9286,6 +9305,7 @@ orchestrator:
       normalize:
       - array
       short: IP address assigned to the resource associated with the event being observed.
+      synthetic_source_keep: none
       type: ip
     orchestrator.resource.label:
       dashed_name: orchestrator-resource-label
@@ -9298,6 +9318,7 @@ orchestrator:
       normalize:
       - array
       short: The list of labels added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
@@ -11232,6 +11253,7 @@ process:
       normalize:
       - array
       short: Array of environment variable bindings.
+      synthetic_source_keep: none
       type: keyword
     process.executable:
       dashed_name: process-executable
@@ -13695,6 +13717,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.capabilities.permitted:
       dashed_name: process-parent-thread-capabilities-permitted
@@ -13710,6 +13733,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
@@ -14904,6 +14928,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.thread.capabilities.permitted:
       dashed_name: process-thread-capabilities-permitted
@@ -14918,6 +14943,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.thread.id:
       dashed_name: process-thread-id
@@ -15412,6 +15438,7 @@ related:
       normalize:
       - array
       short: All the hashes seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.hosts:
       dashed_name: related-hosts
@@ -15424,6 +15451,7 @@ related:
       normalize:
       - array
       short: All the host identifiers seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.ip:
       dashed_name: related-ip
@@ -15434,6 +15462,7 @@ related:
       normalize:
       - array
       short: All of the IPs seen on your event.
+      synthetic_source_keep: none
       type: ip
     related.user:
       dashed_name: related-user
@@ -15445,6 +15474,7 @@ related:
       normalize:
       - array
       short: All the user names or other user identifiers seen on the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: related
@@ -15567,6 +15597,7 @@ rule:
       normalize:
       - array
       short: Rule author
+      synthetic_source_keep: none
       type: keyword
     rule.category:
       dashed_name: rule-category
@@ -16164,6 +16195,7 @@ server:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: server
@@ -16340,6 +16372,7 @@ service:
       normalize:
       - array
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -16498,6 +16531,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -16709,6 +16743,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.target.state:
       dashed_name: service-target-state
@@ -17299,6 +17334,7 @@ source:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: source
@@ -17346,6 +17382,7 @@ threat:
       normalize:
       - array
       short: List of objects containing indicators enriching the event.
+      synthetic_source_keep: none
       type: nested
     threat.enrichments.indicator:
       dashed_name: threat-enrichments-indicator
@@ -17454,6 +17491,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.enrichments.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -20059,6 +20097,7 @@ threat:
       normalize:
       - array
       short: Alias of the group.
+      synthetic_source_keep: none
       type: keyword
     threat.group.id:
       dashed_name: threat-group-id
@@ -20197,6 +20236,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -21897,6 +21937,7 @@ threat:
       normalize:
       - array
       short: ID of the indicator
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
@@ -22691,6 +22732,7 @@ threat:
       normalize:
       - array
       short: Alias of the software
+      synthetic_source_keep: none
       type: keyword
     threat.software.id:
       dashed_name: threat-software-id
@@ -22742,6 +22784,7 @@ threat:
       normalize:
       - array
       short: Platforms of the software.
+      synthetic_source_keep: none
       type: keyword
     threat.software.reference:
       dashed_name: threat-software-reference
@@ -24372,6 +24415,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.domain:
       dashed_name: user-domain
@@ -24515,6 +24559,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.email:
       dashed_name: user-email
@@ -24707,6 +24752,7 @@ user:
       normalize:
       - array
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.target.domain:
       dashed_name: user-target-domain
@@ -24838,6 +24884,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: user
@@ -25362,6 +25409,7 @@ vulnerability:
       normalize:
       - array
       short: Category of a vulnerability.
+      synthetic_source_keep: none
       type: keyword
     vulnerability.classification:
       dashed_name: vulnerability-classification

--- a/experimental/generated/elasticsearch/composable/component/base.json
+++ b/experimental/generated/elasticsearch/composable/component/base.json
@@ -17,6 +17,7 @@
         },
         "tags": {
           "ignore_above": 1024,
+          "synthetic_source_keep": "none",
           "type": "keyword"
         }
       }

--- a/experimental/generated/elasticsearch/composable/component/client.json
+++ b/experimental/generated/elasticsearch/composable/component/client.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/container.json
+++ b/experimental/generated/elasticsearch/composable/component/container.json
@@ -54,6 +54,7 @@
                 },
                 "tag": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/destination.json
+++ b/experimental/generated/elasticsearch/composable/component/destination.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/dns.json
+++ b/experimental/generated/elasticsearch/composable/component/dns.json
@@ -34,6 +34,7 @@
             },
             "header_flags": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "id": {

--- a/experimental/generated/elasticsearch/composable/component/email.json
+++ b/experimental/generated/elasticsearch/composable/component/email.json
@@ -72,6 +72,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -80,6 +81,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -99,6 +101,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -117,6 +120,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -125,6 +129,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -142,6 +147,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/event.json
+++ b/experimental/generated/elasticsearch/composable/component/event.json
@@ -18,6 +18,7 @@
             },
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code": {
@@ -98,6 +99,7 @@
             },
             "type": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "url": {

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -13,6 +13,7 @@
             },
             "attributes": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code_signature": {

--- a/experimental/generated/elasticsearch/composable/component/host.json
+++ b/experimental/generated/elasticsearch/composable/component/host.json
@@ -110,6 +110,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/experimental/generated/elasticsearch/composable/component/observer.json
+++ b/experimental/generated/elasticsearch/composable/component/observer.json
@@ -138,6 +138,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/experimental/generated/elasticsearch/composable/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/composable/component/orchestrator.json
@@ -44,6 +44,7 @@
               "properties": {
                 "annotation": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -55,6 +56,7 @@
                 },
                 "label": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "name": {

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -471,6 +471,7 @@
             },
             "env_vars": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "executable": {
@@ -1342,10 +1343,12 @@
                       "properties": {
                         "effective": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "permitted": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         }
                       }
@@ -1821,10 +1824,12 @@
                   "properties": {
                     "effective": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "permitted": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/experimental/generated/elasticsearch/composable/component/related.json
+++ b/experimental/generated/elasticsearch/composable/component/related.json
@@ -10,10 +10,12 @@
           "properties": {
             "hash": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "hosts": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "ip": {
@@ -21,6 +23,7 @@
             },
             "user": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             }
           }

--- a/experimental/generated/elasticsearch/composable/component/rule.json
+++ b/experimental/generated/elasticsearch/composable/component/rule.json
@@ -10,6 +10,7 @@
           "properties": {
             "author": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "category": {

--- a/experimental/generated/elasticsearch/composable/component/server.json
+++ b/experimental/generated/elasticsearch/composable/component/server.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/service.json
+++ b/experimental/generated/elasticsearch/composable/component/service.json
@@ -40,6 +40,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -78,6 +79,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }
@@ -134,6 +136,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/experimental/generated/elasticsearch/composable/component/source.json
+++ b/experimental/generated/elasticsearch/composable/component/source.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -55,6 +55,7 @@
                         },
                         "attributes": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "code_signature": {
@@ -923,6 +924,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -984,6 +986,7 @@
                     },
                     "attributes": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "code_signature": {
@@ -1540,6 +1543,7 @@
                 },
                 "id": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "ip": {
@@ -1801,6 +1805,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -1813,6 +1818,7 @@
                 },
                 "platforms": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "reference": {

--- a/experimental/generated/elasticsearch/composable/component/user.json
+++ b/experimental/generated/elasticsearch/composable/component/user.json
@@ -62,6 +62,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -124,6 +125,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -200,6 +202,7 @@
             },
             "roles": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "target": {
@@ -256,6 +259,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/experimental/generated/elasticsearch/composable/component/vulnerability.json
+++ b/experimental/generated/elasticsearch/composable/component/vulnerability.json
@@ -10,6 +10,7 @@
           "properties": {
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "classification": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -265,6 +265,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -523,6 +524,7 @@
               },
               "tag": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -755,6 +757,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -991,6 +994,7 @@
           },
           "header_flags": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "id": {
@@ -1116,6 +1120,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1124,6 +1129,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1143,6 +1149,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1161,6 +1168,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1169,6 +1177,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1186,6 +1195,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1235,6 +1245,7 @@
           },
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code": {
@@ -1315,6 +1326,7 @@
           },
           "type": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "url": {
@@ -1365,6 +1377,7 @@
           },
           "attributes": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code_signature": {
@@ -2047,6 +2060,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2535,6 +2549,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2643,6 +2658,7 @@
             "properties": {
               "annotation": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -2654,6 +2670,7 @@
               },
               "label": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "name": {
@@ -3216,6 +3233,7 @@
           },
           "env_vars": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "executable": {
@@ -4087,10 +4105,12 @@
                     "properties": {
                       "effective": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "permitted": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       }
                     }
@@ -4566,10 +4586,12 @@
                 "properties": {
                   "effective": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "permitted": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -4686,10 +4708,12 @@
         "properties": {
           "hash": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "hosts": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "ip": {
@@ -4697,6 +4721,7 @@
           },
           "user": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           }
         }
@@ -4705,6 +4730,7 @@
         "properties": {
           "author": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "category": {
@@ -4914,6 +4940,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4954,6 +4981,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4992,6 +5020,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5048,6 +5077,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5245,6 +5275,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -5261,6 +5292,7 @@
       },
       "tags": {
         "ignore_above": 1024,
+        "synthetic_source_keep": "none",
         "type": "keyword"
       },
       "threat": {
@@ -5312,6 +5344,7 @@
                       },
                       "attributes": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "code_signature": {
@@ -6180,6 +6213,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -6241,6 +6275,7 @@
                   },
                   "attributes": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "code_signature": {
@@ -6797,6 +6832,7 @@
               },
               "id": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "ip": {
@@ -7058,6 +7094,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -7070,6 +7107,7 @@
               },
               "platforms": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "reference": {
@@ -7622,6 +7660,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7684,6 +7723,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7760,6 +7800,7 @@
           },
           "roles": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "target": {
@@ -7816,6 +7857,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7962,6 +8004,7 @@
         "properties": {
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "classification": {

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -559,6 +559,7 @@ client.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
@@ -1062,6 +1063,7 @@ container.image.tag:
   normalize:
   - array
   short: Container image tags.
+  synthetic_source_keep: none
   type: keyword
 container.labels:
   dashed_name: container-labels
@@ -1639,6 +1641,7 @@ destination.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 device.id:
   dashed_name: device-id
@@ -2343,6 +2346,7 @@ dns.header_flags:
   normalize:
   - array
   short: Array of DNS header flags.
+  synthetic_source_keep: none
   type: keyword
 dns.id:
   dashed_name: dns-id
@@ -2675,6 +2679,7 @@ email.bcc.address:
   normalize:
   - array
   short: Email address of BCC recipient
+  synthetic_source_keep: none
   type: keyword
 email.cc.address:
   dashed_name: email-cc-address
@@ -2687,6 +2692,7 @@ email.cc.address:
   normalize:
   - array
   short: Email address of CC recipient
+  synthetic_source_keep: none
   type: keyword
 email.content_type:
   dashed_name: email-content-type
@@ -2735,6 +2741,7 @@ email.from.address:
   normalize:
   - array
   short: The sender's email address.
+  synthetic_source_keep: none
   type: keyword
 email.local_id:
   dashed_name: email-local-id
@@ -2784,6 +2791,7 @@ email.reply_to.address:
   normalize:
   - array
   short: Address replies should be delivered to.
+  synthetic_source_keep: none
   type: keyword
 email.sender.address:
   dashed_name: email-sender-address
@@ -2795,6 +2803,7 @@ email.sender.address:
   name: sender.address
   normalize: []
   short: Address of the message sender.
+  synthetic_source_keep: none
   type: keyword
 email.subject:
   dashed_name: email-subject
@@ -2822,6 +2831,7 @@ email.to.address:
   normalize:
   - array
   short: Email address of recipient
+  synthetic_source_keep: none
   type: keyword
 email.x_mailer:
   dashed_name: email-x-mailer
@@ -3168,6 +3178,7 @@ event.category:
   normalize:
   - array
   short: Event category. The second categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.code:
   dashed_name: event-code
@@ -3729,6 +3740,7 @@ event.type:
   normalize:
   - array
   short: Event type. The third categorization field in the hierarchy.
+  synthetic_source_keep: none
   type: keyword
 event.url:
   dashed_name: event-url
@@ -3856,6 +3868,7 @@ file.attributes:
   normalize:
   - array
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 file.code_signature.digest_algorithm:
   dashed_name: file-code-signature-digest-algorithm
@@ -5848,6 +5861,7 @@ host.ip:
   normalize:
   - array
   short: Host ip addresses.
+  synthetic_source_keep: none
   type: ip
 host.mac:
   dashed_name: host-mac
@@ -5865,6 +5879,7 @@ host.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
+  synthetic_source_keep: none
   type: keyword
 host.name:
   dashed_name: host-name
@@ -7125,6 +7140,7 @@ observer.ip:
   normalize:
   - array
   short: IP addresses of the observer.
+  synthetic_source_keep: none
   type: ip
 observer.mac:
   dashed_name: observer-mac
@@ -7142,6 +7158,7 @@ observer.mac:
   - array
   pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
+  synthetic_source_keep: none
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -7404,6 +7421,7 @@ orchestrator.resource.annotation:
   normalize:
   - array
   short: The list of annotations added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.id:
   dashed_name: orchestrator-resource-id
@@ -7426,6 +7444,7 @@ orchestrator.resource.ip:
   normalize:
   - array
   short: IP address assigned to the resource associated with the event being observed.
+  synthetic_source_keep: none
   type: ip
 orchestrator.resource.label:
   dashed_name: orchestrator-resource-label
@@ -7438,6 +7457,7 @@ orchestrator.resource.label:
   normalize:
   - array
   short: The list of labels added to the resource.
+  synthetic_source_keep: none
   type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
@@ -8927,6 +8947,7 @@ process.env_vars:
   normalize:
   - array
   short: Array of environment variable bindings.
+  synthetic_source_keep: none
   type: keyword
 process.executable:
   dashed_name: process-executable
@@ -11383,6 +11404,7 @@ process.parent.thread.capabilities.effective:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.capabilities.permitted:
   dashed_name: process-parent-thread-capabilities-permitted
@@ -11398,6 +11420,7 @@ process.parent.thread.capabilities.permitted:
   original_fieldset: process
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
@@ -12591,6 +12614,7 @@ process.thread.capabilities.effective:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities used for permission checks.
+  synthetic_source_keep: none
   type: keyword
 process.thread.capabilities.permitted:
   dashed_name: process-thread-capabilities-permitted
@@ -12605,6 +12629,7 @@ process.thread.capabilities.permitted:
   - array
   pattern: ^(CAP_[A-Z_]+|\d+)$
   short: Array of capabilities a thread could assume.
+  synthetic_source_keep: none
   type: keyword
 process.thread.id:
   dashed_name: process-thread-id
@@ -12875,6 +12900,7 @@ related.hash:
   normalize:
   - array
   short: All the hashes seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.hosts:
   dashed_name: related-hosts
@@ -12887,6 +12913,7 @@ related.hosts:
   normalize:
   - array
   short: All the host identifiers seen on your event.
+  synthetic_source_keep: none
   type: keyword
 related.ip:
   dashed_name: related-ip
@@ -12897,6 +12924,7 @@ related.ip:
   normalize:
   - array
   short: All of the IPs seen on your event.
+  synthetic_source_keep: none
   type: ip
 related.user:
   dashed_name: related-user
@@ -12908,6 +12936,7 @@ related.user:
   normalize:
   - array
   short: All the user names or other user identifiers seen on the event.
+  synthetic_source_keep: none
   type: keyword
 rule.author:
   dashed_name: rule-author
@@ -12921,6 +12950,7 @@ rule.author:
   normalize:
   - array
   short: Rule author
+  synthetic_source_keep: none
   type: keyword
 rule.category:
   dashed_name: rule-category
@@ -13491,6 +13521,7 @@ server.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 service.address:
   dashed_name: service-address
@@ -13639,6 +13670,7 @@ service.node.roles:
   normalize:
   - array
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -13795,6 +13827,7 @@ service.origin.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -14004,6 +14037,7 @@ service.target.node.roles:
   - array
   original_fieldset: service
   short: Roles of the service node.
+  synthetic_source_keep: none
   type: keyword
 service.target.state:
   dashed_name: service-target-state
@@ -14538,6 +14572,7 @@ source.user.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 span.id:
   dashed_name: span-id
@@ -14564,6 +14599,7 @@ tags:
   normalize:
   - array
   short: List of keywords used to tag each event.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments:
   dashed_name: threat-enrichments
@@ -14575,6 +14611,7 @@ threat.enrichments:
   normalize:
   - array
   short: List of objects containing indicators enriching the event.
+  synthetic_source_keep: none
   type: nested
 threat.enrichments.indicator:
   dashed_name: threat-enrichments-indicator
@@ -14683,6 +14720,7 @@ threat.enrichments.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.enrichments.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -17280,6 +17318,7 @@ threat.group.alias:
   normalize:
   - array
   short: Alias of the group.
+  synthetic_source_keep: none
   type: keyword
 threat.group.id:
   dashed_name: threat-group-id
@@ -17418,6 +17457,7 @@ threat.indicator.file.attributes:
   - array
   original_fieldset: file
   short: Array of file attributes.
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.file.code_signature.digest_algorithm:
   dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -19115,6 +19155,7 @@ threat.indicator.id:
   normalize:
   - array
   short: ID of the indicator
+  synthetic_source_keep: none
   type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
@@ -19904,6 +19945,7 @@ threat.software.alias:
   normalize:
   - array
   short: Alias of the software
+  synthetic_source_keep: none
   type: keyword
 threat.software.id:
   dashed_name: threat-software-id
@@ -19955,6 +19997,7 @@ threat.software.platforms:
   normalize:
   - array
   short: Platforms of the software.
+  synthetic_source_keep: none
   type: keyword
 threat.software.reference:
   dashed_name: threat-software-reference
@@ -21441,6 +21484,7 @@ user.changes.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.domain:
   dashed_name: user-domain
@@ -21584,6 +21628,7 @@ user.effective.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.email:
   dashed_name: user-email
@@ -21776,6 +21821,7 @@ user.roles:
   normalize:
   - array
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user.target.domain:
   dashed_name: user-target-domain
@@ -21907,6 +21953,7 @@ user.target.roles:
   - array
   original_fieldset: user
   short: Array of user roles at the time of the event.
+  synthetic_source_keep: none
   type: keyword
 user_agent.device.name:
   dashed_name: user-agent-device-name
@@ -22266,6 +22313,7 @@ vulnerability.category:
   normalize:
   - array
   short: Category of a vulnerability.
+  synthetic_source_keep: none
   type: keyword
 vulnerability.classification:
   dashed_name: vulnerability-classification

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -224,6 +224,7 @@ base:
       normalize:
       - array
       short: List of keywords used to tag each event.
+      synthetic_source_keep: none
       type: keyword
   group: 1
   name: base
@@ -711,6 +712,7 @@ client:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: client
@@ -1442,6 +1444,7 @@ container:
       normalize:
       - array
       short: Container image tags.
+      synthetic_source_keep: none
       type: keyword
     container.labels:
       dashed_name: container-labels
@@ -2062,6 +2065,7 @@ destination:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: destination
@@ -2847,6 +2851,7 @@ dns:
       normalize:
       - array
       short: Array of DNS header flags.
+      synthetic_source_keep: none
       type: keyword
     dns.id:
       dashed_name: dns-id
@@ -3629,6 +3634,7 @@ email:
       normalize:
       - array
       short: Email address of BCC recipient
+      synthetic_source_keep: none
       type: keyword
     email.cc.address:
       dashed_name: email-cc-address
@@ -3641,6 +3647,7 @@ email:
       normalize:
       - array
       short: Email address of CC recipient
+      synthetic_source_keep: none
       type: keyword
     email.content_type:
       dashed_name: email-content-type
@@ -3690,6 +3697,7 @@ email:
       normalize:
       - array
       short: The sender's email address.
+      synthetic_source_keep: none
       type: keyword
     email.local_id:
       dashed_name: email-local-id
@@ -3739,6 +3747,7 @@ email:
       normalize:
       - array
       short: Address replies should be delivered to.
+      synthetic_source_keep: none
       type: keyword
     email.sender.address:
       dashed_name: email-sender-address
@@ -3750,6 +3759,7 @@ email:
       name: sender.address
       normalize: []
       short: Address of the message sender.
+      synthetic_source_keep: none
       type: keyword
     email.subject:
       dashed_name: email-subject
@@ -3777,6 +3787,7 @@ email:
       normalize:
       - array
       short: Email address of recipient
+      synthetic_source_keep: none
       type: keyword
     email.x_mailer:
       dashed_name: email-x-mailer
@@ -4164,6 +4175,7 @@ event:
       normalize:
       - array
       short: Event category. The second categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.code:
       dashed_name: event-code
@@ -4737,6 +4749,7 @@ event:
       normalize:
       - array
       short: Event type. The third categorization field in the hierarchy.
+      synthetic_source_keep: none
       type: keyword
     event.url:
       dashed_name: event-url
@@ -4890,6 +4903,7 @@ file:
       normalize:
       - array
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     file.code_signature.digest_algorithm:
       dashed_name: file-code-signature-digest-algorithm
@@ -7264,6 +7278,7 @@ host:
       normalize:
       - array
       short: Host ip addresses.
+      synthetic_source_keep: none
       type: ip
     host.mac:
       dashed_name: host-mac
@@ -7282,6 +7297,7 @@ host:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
+      synthetic_source_keep: none
       type: keyword
     host.name:
       dashed_name: host-name
@@ -8866,6 +8882,7 @@ observer:
       normalize:
       - array
       short: IP addresses of the observer.
+      synthetic_source_keep: none
       type: ip
     observer.mac:
       dashed_name: observer-mac
@@ -8884,6 +8901,7 @@ observer:
       - array
       pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
+      synthetic_source_keep: none
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -9183,6 +9201,7 @@ orchestrator:
       normalize:
       - array
       short: The list of annotations added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.id:
       dashed_name: orchestrator-resource-id
@@ -9206,6 +9225,7 @@ orchestrator:
       normalize:
       - array
       short: IP address assigned to the resource associated with the event being observed.
+      synthetic_source_keep: none
       type: ip
     orchestrator.resource.label:
       dashed_name: orchestrator-resource-label
@@ -9218,6 +9238,7 @@ orchestrator:
       normalize:
       - array
       short: The list of labels added to the resource.
+      synthetic_source_keep: none
       type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
@@ -11152,6 +11173,7 @@ process:
       normalize:
       - array
       short: Array of environment variable bindings.
+      synthetic_source_keep: none
       type: keyword
     process.executable:
       dashed_name: process-executable
@@ -13615,6 +13637,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.capabilities.permitted:
       dashed_name: process-parent-thread-capabilities-permitted
@@ -13630,6 +13653,7 @@ process:
       original_fieldset: process
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
@@ -14824,6 +14848,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities used for permission checks.
+      synthetic_source_keep: none
       type: keyword
     process.thread.capabilities.permitted:
       dashed_name: process-thread-capabilities-permitted
@@ -14838,6 +14863,7 @@ process:
       - array
       pattern: ^(CAP_[A-Z_]+|\d+)$
       short: Array of capabilities a thread could assume.
+      synthetic_source_keep: none
       type: keyword
     process.thread.id:
       dashed_name: process-thread-id
@@ -15332,6 +15358,7 @@ related:
       normalize:
       - array
       short: All the hashes seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.hosts:
       dashed_name: related-hosts
@@ -15344,6 +15371,7 @@ related:
       normalize:
       - array
       short: All the host identifiers seen on your event.
+      synthetic_source_keep: none
       type: keyword
     related.ip:
       dashed_name: related-ip
@@ -15354,6 +15382,7 @@ related:
       normalize:
       - array
       short: All of the IPs seen on your event.
+      synthetic_source_keep: none
       type: ip
     related.user:
       dashed_name: related-user
@@ -15365,6 +15394,7 @@ related:
       normalize:
       - array
       short: All the user names or other user identifiers seen on the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: related
@@ -15487,6 +15517,7 @@ rule:
       normalize:
       - array
       short: Rule author
+      synthetic_source_keep: none
       type: keyword
     rule.category:
       dashed_name: rule-category
@@ -16084,6 +16115,7 @@ server:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: server
@@ -16260,6 +16292,7 @@ service:
       normalize:
       - array
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -16418,6 +16451,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -16629,6 +16663,7 @@ service:
       - array
       original_fieldset: service
       short: Roles of the service node.
+      synthetic_source_keep: none
       type: keyword
     service.target.state:
       dashed_name: service-target-state
@@ -17219,6 +17254,7 @@ source:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: source
@@ -17266,6 +17302,7 @@ threat:
       normalize:
       - array
       short: List of objects containing indicators enriching the event.
+      synthetic_source_keep: none
       type: nested
     threat.enrichments.indicator:
       dashed_name: threat-enrichments-indicator
@@ -17374,6 +17411,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.enrichments.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
@@ -19979,6 +20017,7 @@ threat:
       normalize:
       - array
       short: Alias of the group.
+      synthetic_source_keep: none
       type: keyword
     threat.group.id:
       dashed_name: threat-group-id
@@ -20117,6 +20156,7 @@ threat:
       - array
       original_fieldset: file
       short: Array of file attributes.
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.file.code_signature.digest_algorithm:
       dashed_name: threat-indicator-file-code-signature-digest-algorithm
@@ -21817,6 +21857,7 @@ threat:
       normalize:
       - array
       short: ID of the indicator
+      synthetic_source_keep: none
       type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
@@ -22611,6 +22652,7 @@ threat:
       normalize:
       - array
       short: Alias of the software
+      synthetic_source_keep: none
       type: keyword
     threat.software.id:
       dashed_name: threat-software-id
@@ -22662,6 +22704,7 @@ threat:
       normalize:
       - array
       short: Platforms of the software.
+      synthetic_source_keep: none
       type: keyword
     threat.software.reference:
       dashed_name: threat-software-reference
@@ -24292,6 +24335,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.domain:
       dashed_name: user-domain
@@ -24435,6 +24479,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.email:
       dashed_name: user-email
@@ -24627,6 +24672,7 @@ user:
       normalize:
       - array
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
     user.target.domain:
       dashed_name: user-target-domain
@@ -24758,6 +24804,7 @@ user:
       - array
       original_fieldset: user
       short: Array of user roles at the time of the event.
+      synthetic_source_keep: none
       type: keyword
   group: 2
   name: user
@@ -25282,6 +25329,7 @@ vulnerability:
       normalize:
       - array
       short: Category of a vulnerability.
+      synthetic_source_keep: none
       type: keyword
     vulnerability.classification:
       dashed_name: vulnerability-classification

--- a/generated/elasticsearch/composable/component/base.json
+++ b/generated/elasticsearch/composable/component/base.json
@@ -17,6 +17,7 @@
         },
         "tags": {
           "ignore_above": 1024,
+          "synthetic_source_keep": "none",
           "type": "keyword"
         }
       }

--- a/generated/elasticsearch/composable/component/client.json
+++ b/generated/elasticsearch/composable/component/client.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/container.json
+++ b/generated/elasticsearch/composable/component/container.json
@@ -54,6 +54,7 @@
                 },
                 "tag": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/destination.json
+++ b/generated/elasticsearch/composable/component/destination.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/dns.json
+++ b/generated/elasticsearch/composable/component/dns.json
@@ -34,6 +34,7 @@
             },
             "header_flags": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "id": {

--- a/generated/elasticsearch/composable/component/email.json
+++ b/generated/elasticsearch/composable/component/email.json
@@ -72,6 +72,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -80,6 +81,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -99,6 +101,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -117,6 +120,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -125,6 +129,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -142,6 +147,7 @@
               "properties": {
                 "address": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/event.json
+++ b/generated/elasticsearch/composable/component/event.json
@@ -18,6 +18,7 @@
             },
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code": {
@@ -98,6 +99,7 @@
             },
             "type": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "url": {

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -13,6 +13,7 @@
             },
             "attributes": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "code_signature": {

--- a/generated/elasticsearch/composable/component/host.json
+++ b/generated/elasticsearch/composable/component/host.json
@@ -110,6 +110,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/generated/elasticsearch/composable/component/observer.json
+++ b/generated/elasticsearch/composable/component/observer.json
@@ -138,6 +138,7 @@
             },
             "mac": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "name": {

--- a/generated/elasticsearch/composable/component/orchestrator.json
+++ b/generated/elasticsearch/composable/component/orchestrator.json
@@ -44,6 +44,7 @@
               "properties": {
                 "annotation": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -55,6 +56,7 @@
                 },
                 "label": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "name": {

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -471,6 +471,7 @@
             },
             "env_vars": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "executable": {
@@ -1342,10 +1343,12 @@
                       "properties": {
                         "effective": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "permitted": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         }
                       }
@@ -1821,10 +1824,12 @@
                   "properties": {
                     "effective": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "permitted": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/generated/elasticsearch/composable/component/related.json
+++ b/generated/elasticsearch/composable/component/related.json
@@ -10,10 +10,12 @@
           "properties": {
             "hash": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "hosts": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "ip": {
@@ -21,6 +23,7 @@
             },
             "user": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             }
           }

--- a/generated/elasticsearch/composable/component/rule.json
+++ b/generated/elasticsearch/composable/component/rule.json
@@ -10,6 +10,7 @@
           "properties": {
             "author": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "category": {

--- a/generated/elasticsearch/composable/component/server.json
+++ b/generated/elasticsearch/composable/component/server.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/service.json
+++ b/generated/elasticsearch/composable/component/service.json
@@ -40,6 +40,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -78,6 +79,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }
@@ -134,6 +136,7 @@
                     },
                     "roles": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     }
                   }

--- a/generated/elasticsearch/composable/component/source.json
+++ b/generated/elasticsearch/composable/component/source.json
@@ -175,6 +175,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -55,6 +55,7 @@
                         },
                         "attributes": {
                           "ignore_above": 1024,
+                          "synthetic_source_keep": "none",
                           "type": "keyword"
                         },
                         "code_signature": {
@@ -923,6 +924,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -984,6 +986,7 @@
                     },
                     "attributes": {
                       "ignore_above": 1024,
+                      "synthetic_source_keep": "none",
                       "type": "keyword"
                     },
                     "code_signature": {
@@ -1540,6 +1543,7 @@
                 },
                 "id": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "ip": {
@@ -1801,6 +1805,7 @@
               "properties": {
                 "alias": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "id": {
@@ -1813,6 +1818,7 @@
                 },
                 "platforms": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 },
                 "reference": {

--- a/generated/elasticsearch/composable/component/user.json
+++ b/generated/elasticsearch/composable/component/user.json
@@ -62,6 +62,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -124,6 +125,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }
@@ -200,6 +202,7 @@
             },
             "roles": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "target": {
@@ -256,6 +259,7 @@
                 },
                 "roles": {
                   "ignore_above": 1024,
+                  "synthetic_source_keep": "none",
                   "type": "keyword"
                 }
               }

--- a/generated/elasticsearch/composable/component/vulnerability.json
+++ b/generated/elasticsearch/composable/component/vulnerability.json
@@ -10,6 +10,7 @@
           "properties": {
             "category": {
               "ignore_above": 1024,
+              "synthetic_source_keep": "none",
               "type": "keyword"
             },
             "classification": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -223,6 +223,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -481,6 +482,7 @@
               },
               "tag": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -713,6 +715,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -949,6 +952,7 @@
           },
           "header_flags": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "id": {
@@ -1074,6 +1078,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1082,6 +1087,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1101,6 +1107,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1119,6 +1126,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1127,6 +1135,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1144,6 +1153,7 @@
             "properties": {
               "address": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -1193,6 +1203,7 @@
           },
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code": {
@@ -1273,6 +1284,7 @@
           },
           "type": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "url": {
@@ -1323,6 +1335,7 @@
           },
           "attributes": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "code_signature": {
@@ -2005,6 +2018,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2493,6 +2507,7 @@
           },
           "mac": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "name": {
@@ -2601,6 +2616,7 @@
             "properties": {
               "annotation": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -2612,6 +2628,7 @@
               },
               "label": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "name": {
@@ -3174,6 +3191,7 @@
           },
           "env_vars": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "executable": {
@@ -4045,10 +4063,12 @@
                     "properties": {
                       "effective": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "permitted": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       }
                     }
@@ -4524,10 +4544,12 @@
                 "properties": {
                   "effective": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "permitted": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -4644,10 +4666,12 @@
         "properties": {
           "hash": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "hosts": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "ip": {
@@ -4655,6 +4679,7 @@
           },
           "user": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           }
         }
@@ -4663,6 +4688,7 @@
         "properties": {
           "author": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "category": {
@@ -4872,6 +4898,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4912,6 +4939,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -4950,6 +4978,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5006,6 +5035,7 @@
                   },
                   "roles": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   }
                 }
@@ -5203,6 +5233,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -5219,6 +5250,7 @@
       },
       "tags": {
         "ignore_above": 1024,
+        "synthetic_source_keep": "none",
         "type": "keyword"
       },
       "threat": {
@@ -5270,6 +5302,7 @@
                       },
                       "attributes": {
                         "ignore_above": 1024,
+                        "synthetic_source_keep": "none",
                         "type": "keyword"
                       },
                       "code_signature": {
@@ -6138,6 +6171,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -6199,6 +6233,7 @@
                   },
                   "attributes": {
                     "ignore_above": 1024,
+                    "synthetic_source_keep": "none",
                     "type": "keyword"
                   },
                   "code_signature": {
@@ -6755,6 +6790,7 @@
               },
               "id": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "ip": {
@@ -7016,6 +7052,7 @@
             "properties": {
               "alias": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "id": {
@@ -7028,6 +7065,7 @@
               },
               "platforms": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               },
               "reference": {
@@ -7580,6 +7618,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7642,6 +7681,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7718,6 +7758,7 @@
           },
           "roles": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "target": {
@@ -7774,6 +7815,7 @@
               },
               "roles": {
                 "ignore_above": 1024,
+                "synthetic_source_keep": "none",
                 "type": "keyword"
               }
             }
@@ -7920,6 +7962,7 @@
         "properties": {
           "category": {
             "ignore_above": 1024,
+            "synthetic_source_keep": "none",
             "type": "keyword"
           },
           "classification": {

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -50,6 +50,7 @@
         List of keywords used to tag each event.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: labels
       level: core

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -71,6 +71,7 @@
         Container image tags.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: image.hash.all
       level: extended

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -79,6 +79,7 @@
       example: "[\"RD\", \"RA\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: response_code
       level: extended

--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -79,6 +79,7 @@
       example: "bcc.user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: cc.address
       level: extended
@@ -89,6 +90,7 @@
       example: "cc.user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: content_type
       level: extended
@@ -125,6 +127,7 @@
       example: "sender@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: local_id
       level: extended
@@ -163,6 +166,7 @@
       example: "reply.here@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: sender.address
       level: extended
@@ -171,6 +175,7 @@
       description: >
         Per RFC 5322, specifies the address responsible for the actual transmission of
         the message.
+      synthetic_source_keep: "none"
 
     - name: subject
       level: extended
@@ -192,6 +197,7 @@
       example: "user1@example.com"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: x_mailer
       level: extended

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -173,6 +173,7 @@
       example: authentication
       normalize:
         - array
+      synthetic_source_keep: "none"
       allowed_values:
         - name: api
           description: >
@@ -466,6 +467,7 @@
         that fall in multiple event types.
       normalize:
         - array
+      synthetic_source_keep: "none"
       allowed_values:
         - name: access
           description: >

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -53,7 +53,7 @@
       example: '["readonly", "system"]'
       normalize:
         - array
-
+      synthetic_source_keep: "none"
     - name: directory
       level: extended
       type: keyword

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -66,6 +66,7 @@
         Host ip addresses.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: mac
       level: core
@@ -82,6 +83,7 @@
         hyphen.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: type
       level: core

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -48,6 +48,7 @@
         hyphen.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: ip
       level: core
@@ -56,6 +57,7 @@
         IP addresses of the observer.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: hostname
       level: core

--- a/schemas/orchestrator.yml
+++ b/schemas/orchestrator.yml
@@ -77,6 +77,7 @@
         The list of annotations added to the resource.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.label
       level: extended
@@ -86,6 +87,7 @@
         The list of labels added to the resource.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.name
       level: extended
@@ -119,6 +121,7 @@
         In the case of a Kubernetes Pod, this array would contain only one element: the IP of the Pod (as opposed to the Node on which the Pod is running).
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: resource.id
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -233,6 +233,7 @@
       example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: thread.capabilities.effective
       level: extended
@@ -245,6 +246,7 @@
       example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: start
       level: extended
@@ -336,6 +338,7 @@
       example: "[\"PATH=/usr/local/bin:/usr/bin\", \"USER=ubuntu\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: entry_meta.type
       level: extended

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -40,6 +40,7 @@
         All of the IPs seen on your event.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: user
       level: extended
@@ -49,6 +50,7 @@
 
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: hash
       level: extended
@@ -60,6 +62,7 @@
         the hash algorithm is (and therefore which key name to search).
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: hosts
       level: extended
@@ -70,3 +73,4 @@
         identifiers include FQDNs, domain names, workstation names, or aliases.
       normalize:
         - array
+      synthetic_source_keep: "none"

--- a/schemas/rule.yml
+++ b/schemas/rule.yml
@@ -107,6 +107,7 @@
       example: "[\"Star-Lord\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: license
       level: extended

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -141,6 +141,7 @@
       example: "[\"ui\", \"background_tasks\"]"
       normalize:
         - array
+      synthetic_source_keep: "none"
       short: Roles of the service node.
       description: >
         Roles of a service node.

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -39,6 +39,7 @@
         that association/enrichment.
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: enrichments.indicator
       level: extended
@@ -311,6 +312,7 @@
       example: '[ "Magecart Group 6" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: group.id
       level: extended
@@ -527,6 +529,7 @@
       example: "[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]"
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.id
       level: extended
@@ -560,6 +563,7 @@
       example: '[ "X-Agent" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.platforms
       level: extended
@@ -583,6 +587,7 @@
       example: '[ "Windows" ]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: software.reference
       level: extended

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -116,6 +116,7 @@
       type: keyword
       normalize:
         - array
+      synthetic_source_keep: "none"
       description: >
         Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -125,6 +125,7 @@
       example: '["Firewall"]'
       normalize:
         - array
+      synthetic_source_keep: "none"
 
     - name: description
       level: extended

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -181,7 +181,7 @@ def entry_for(field: Field) -> Dict:
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['index', 'doc_values'])
 
         if field['type'] == 'keyword' or field['type'] == 'flattened':
-            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above'])
+            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above', 'synthetic_source_keep'])
         elif field['type'] == 'constant_keyword':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['value'])
         elif field['type'] == 'text':


### PR DESCRIPTION
Add support for synthetic_source_keep mapping in generated elasticsearch component files, and add this mapping field to all ECS fields that represent sets.

synthetic_source_keep = none indicates that field is an unordered set, and helps improve storage efficiency with Elasticsearch logsdb index mode.
