### PR TITLE
[Backport 8.x] Fix link rendering issues and usage of http in links

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Fix link rendering issues and usage of http in links. #2423
+
 #### Added
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -475,7 +475,7 @@ a| The highest registered client domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -511,7 +511,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -1537,7 +1537,7 @@ a| The highest registered destination domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -1573,7 +1573,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -2056,7 +2056,7 @@ a| The highest registered domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -2092,7 +2092,7 @@ example: `www`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -2320,7 +2320,7 @@ Note: this field should contain an array of values.
 
 a| A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 
@@ -6035,7 +6035,7 @@ beta::[ These fields are in beta and are subject to change.]
 
 a| A hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 
@@ -7688,7 +7688,7 @@ example: `6.3.9600.17415`
 
 a| A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
 
-The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
+The algorithm used to calculate the Go symbol hash and a reference implementation are available here: https://github.com/elastic/toutoumomoma
 
 type: keyword
 
@@ -9693,7 +9693,7 @@ a| The highest registered server domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -9729,7 +9729,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -10252,7 +10252,7 @@ a| The highest registered source domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -10288,7 +10288,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -12477,7 +12477,7 @@ a| The highest registered url domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
 type: keyword
 
@@ -12531,7 +12531,7 @@ example: `east`
 
 a| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
-This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
+This value can be determined precisely with a list like the public suffix list (https://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
 type: keyword
 
@@ -13310,7 +13310,7 @@ The vulnerability fields describe information about a vulnerability that is rele
 [[field-vulnerability-category]]
 <<field-vulnerability-category, vulnerability.category>>
 
-a| The type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys vulnerability categories])
+a| The type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
 This field must be an array.
 
@@ -13347,7 +13347,7 @@ example: `CVSS`
 [[field-vulnerability-description]]
 <<field-vulnerability-description, vulnerability.description>>
 
-a| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+a| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
 
 type: keyword
 
@@ -13385,7 +13385,7 @@ example: `CVE`
 [[field-vulnerability-id]]
 <<field-vulnerability-id, vulnerability.id>>
 
-a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
+a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -362,7 +362,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -388,7 +388,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1080,7 +1080,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -1106,7 +1106,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1444,7 +1444,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1683,7 +1683,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: question.subdomain
@@ -1704,7 +1704,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: question.type
@@ -2585,7 +2585,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2891,7 +2891,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3076,7 +3076,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4916,7 +4916,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5965,7 +5965,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6241,7 +6241,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6612,7 +6612,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6767,7 +6767,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7139,7 +7139,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -8252,7 +8252,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8278,7 +8278,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -8980,7 +8980,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -9006,7 +9006,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -9330,7 +9330,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9718,7 +9718,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10390,7 +10390,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -10426,7 +10426,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -10952,7 +10952,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11340,7 +11340,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports
@@ -12023,7 +12023,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -12059,7 +12059,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -13085,7 +13085,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: scheme
@@ -13119,7 +13119,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: username
@@ -13727,8 +13727,7 @@
       ignore_above: 1024
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -13749,8 +13748,7 @@
       - name: text
         type: match_only_text
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       default_field: false
     - name: enumeration
@@ -13767,8 +13765,7 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -453,7 +453,7 @@ client.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: client.registered_domain
@@ -488,7 +488,7 @@ client.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: client.top_level_domain
@@ -1533,7 +1533,7 @@ destination.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: destination.registered_domain
@@ -1568,7 +1568,7 @@ destination.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: destination.top_level_domain
@@ -2082,7 +2082,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -2472,7 +2472,7 @@ dns.question.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: dns.question.registered_domain
@@ -2503,7 +2503,7 @@ dns.question.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: dns.question.top_level_domain
@@ -4189,7 +4189,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4734,7 +4734,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -5051,7 +5051,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -7976,7 +7976,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9688,7 +9688,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10147,7 +10147,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -10785,7 +10785,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -11049,7 +11049,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11676,7 +11676,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -13385,7 +13385,7 @@ server.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: server.registered_domain
@@ -13420,7 +13420,7 @@ server.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: server.top_level_domain
@@ -14432,7 +14432,7 @@ source.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: source.registered_domain
@@ -14467,7 +14467,7 @@ source.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: source.top_level_domain
@@ -15021,7 +15021,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -15696,7 +15696,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -16831,7 +16831,7 @@ threat.enrichments.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.enrichments.indicator.url.registered_domain
@@ -16882,7 +16882,7 @@ threat.enrichments.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -17756,7 +17756,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18431,7 +18431,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -19582,7 +19582,7 @@ threat.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.indicator.url.registered_domain
@@ -19633,7 +19633,7 @@ threat.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.indicator.url.top_level_domain
@@ -21312,7 +21312,7 @@ url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: url.registered_domain
@@ -21360,7 +21360,7 @@ url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: url.top_level_domain
@@ -22323,8 +22323,7 @@ vulnerability.category:
   dashed_name: vulnerability-category
   description: 'The type of system or architecture that the vulnerability affects.
     These may be platform-specific (for example, Debian or SUSE) or general (for example,
-    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-    vulnerability categories])
+    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
     This field must be an array.'
   example: '["Firewall"]'
@@ -22351,8 +22350,7 @@ vulnerability.classification:
 vulnerability.description:
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
-    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-    Vulnerabilities and Exposure CVE description])
+    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
   example: In macOS before 2.12.6, there is a vulnerability in the RPC...
   flat_name: vulnerability.description
   ignore_above: 1024
@@ -22380,8 +22378,7 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
-    Exposure CVE ID])
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -616,7 +616,7 @@ client:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: client.registered_domain
@@ -651,7 +651,7 @@ client:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: client.top_level_domain
@@ -1967,7 +1967,7 @@ destination:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: destination.registered_domain
@@ -2002,7 +2002,7 @@ destination:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: destination.top_level_domain
@@ -2567,7 +2567,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -2988,7 +2988,7 @@ dns:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: dns.question.registered_domain
@@ -3019,7 +3019,7 @@ dns:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: dns.question.top_level_domain
@@ -3182,7 +3182,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5234,7 +5234,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5780,7 +5780,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6098,7 +6098,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8153,7 +8153,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9725,7 +9725,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10211,7 +10211,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -11927,7 +11927,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12387,7 +12387,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -13026,7 +13026,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13291,7 +13291,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -13919,7 +13919,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -15989,7 +15989,7 @@ server:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: server.registered_domain
@@ -16024,7 +16024,7 @@ server:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: server.top_level_domain
@@ -17124,7 +17124,7 @@ source:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: source.registered_domain
@@ -17159,7 +17159,7 @@ source:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: source.top_level_domain
@@ -17723,7 +17723,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18399,7 +18399,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19540,7 +19540,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.enrichments.indicator.url.registered_domain
@@ -19591,7 +19591,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -20466,7 +20466,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21142,7 +21142,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -22299,7 +22299,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.indicator.url.registered_domain
@@ -22350,7 +22350,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.indicator.url.top_level_domain
@@ -24152,7 +24152,7 @@ url:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: url.registered_domain
@@ -24200,7 +24200,7 @@ url:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: url.top_level_domain
@@ -25350,8 +25350,7 @@ vulnerability:
       dashed_name: vulnerability-category
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -25378,8 +25377,7 @@ vulnerability:
     vulnerability.description:
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       flat_name: vulnerability.description
       ignore_above: 1024
@@ -25408,8 +25406,7 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -312,7 +312,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -338,7 +338,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1030,7 +1030,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -1056,7 +1056,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -1394,7 +1394,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1633,7 +1633,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: question.subdomain
@@ -1654,7 +1654,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: question.type
@@ -2535,7 +2535,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -2841,7 +2841,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3026,7 +3026,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4866,7 +4866,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -5915,7 +5915,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6191,7 +6191,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -6562,7 +6562,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -6717,7 +6717,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7089,7 +7089,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -8202,7 +8202,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8228,7 +8228,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -8930,7 +8930,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: subdomain
@@ -8956,7 +8956,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: user.domain
@@ -9280,7 +9280,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -9668,7 +9668,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -10340,7 +10340,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -10376,7 +10376,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -10902,7 +10902,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11290,7 +11290,7 @@
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports
@@ -11973,7 +11973,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       default_field: false
@@ -12009,7 +12009,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       default_field: false
@@ -13035,7 +13035,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
     - name: scheme
@@ -13069,7 +13069,7 @@
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
     - name: username
@@ -13677,8 +13677,7 @@
       ignore_above: 1024
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -13699,8 +13698,7 @@
       - name: text
         type: match_only_text
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       default_field: false
     - name: enumeration
@@ -13717,8 +13715,7 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -384,7 +384,7 @@ client.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: client.registered_domain
@@ -419,7 +419,7 @@ client.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: client.top_level_domain
@@ -1464,7 +1464,7 @@ destination.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: destination.registered_domain
@@ -1499,7 +1499,7 @@ destination.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: destination.top_level_domain
@@ -2013,7 +2013,7 @@ dll.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -2403,7 +2403,7 @@ dns.question.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: dns.question.registered_domain
@@ -2434,7 +2434,7 @@ dns.question.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: dns.question.top_level_domain
@@ -4120,7 +4120,7 @@ file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4665,7 +4665,7 @@ file.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -4982,7 +4982,7 @@ file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -7907,7 +7907,7 @@ process.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9619,7 +9619,7 @@ process.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -10078,7 +10078,7 @@ process.parent.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -10716,7 +10716,7 @@ process.parent.macho.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -10980,7 +10980,7 @@ process.parent.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11607,7 +11607,7 @@ process.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -13316,7 +13316,7 @@ server.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: server.registered_domain
@@ -13351,7 +13351,7 @@ server.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: server.top_level_domain
@@ -14363,7 +14363,7 @@ source.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: source.registered_domain
@@ -14398,7 +14398,7 @@ source.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: source.top_level_domain
@@ -14952,7 +14952,7 @@ threat.enrichments.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -15627,7 +15627,7 @@ threat.enrichments.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -16762,7 +16762,7 @@ threat.enrichments.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.enrichments.indicator.url.registered_domain
@@ -16813,7 +16813,7 @@ threat.enrichments.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -17687,7 +17687,7 @@ threat.indicator.file.elf.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -18362,7 +18362,7 @@ threat.indicator.file.pe.go_import_hash:
     more traditional hash values.
 
     The algorithm used to calculate the Go symbol hash and a reference implementation
-    are available [here](https://github.com/elastic/toutoumomoma).'
+    are available here: https://github.com/elastic/toutoumomoma'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -19513,7 +19513,7 @@ threat.indicator.url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: threat.indicator.url.registered_domain
@@ -19564,7 +19564,7 @@ threat.indicator.url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: threat.indicator.url.top_level_domain
@@ -21243,7 +21243,7 @@ url.registered_domain:
     For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: url.registered_domain
@@ -21291,7 +21291,7 @@ url.top_level_domain:
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
-    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    (https://publicsuffix.org). Trying to approximate this by simply taking the last
     label will not work well for effective TLDs such as "co.uk".'
   example: co.uk
   flat_name: url.top_level_domain
@@ -22254,8 +22254,7 @@ vulnerability.category:
   dashed_name: vulnerability-category
   description: 'The type of system or architecture that the vulnerability affects.
     These may be platform-specific (for example, Debian or SUSE) or general (for example,
-    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-    vulnerability categories])
+    Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
     This field must be an array.'
   example: '["Firewall"]'
@@ -22282,8 +22281,7 @@ vulnerability.classification:
 vulnerability.description:
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
-    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-    Vulnerabilities and Exposure CVE description])
+    of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
   example: In macOS before 2.12.6, there is a vulnerability in the RPC...
   flat_name: vulnerability.description
   ignore_above: 1024
@@ -22311,8 +22309,7 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
-    Exposure CVE ID])
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -536,7 +536,7 @@ client:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: client.registered_domain
@@ -571,7 +571,7 @@ client:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: client.top_level_domain
@@ -1887,7 +1887,7 @@ destination:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: destination.registered_domain
@@ -1922,7 +1922,7 @@ destination:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: destination.top_level_domain
@@ -2487,7 +2487,7 @@ dll:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -2908,7 +2908,7 @@ dns:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: dns.question.registered_domain
@@ -2939,7 +2939,7 @@ dns:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: dns.question.top_level_domain
@@ -3102,7 +3102,7 @@ elf:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5154,7 +5154,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5700,7 +5700,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -6018,7 +6018,7 @@ file:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -8073,7 +8073,7 @@ macho:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9645,7 +9645,7 @@ pe:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -10131,7 +10131,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -11847,7 +11847,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12307,7 +12307,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -12946,7 +12946,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -13211,7 +13211,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -13839,7 +13839,7 @@ process:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -15909,7 +15909,7 @@ server:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: server.registered_domain
@@ -15944,7 +15944,7 @@ server:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: server.top_level_domain
@@ -17044,7 +17044,7 @@ source:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: source.registered_domain
@@ -17079,7 +17079,7 @@ source:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: source.top_level_domain
@@ -17643,7 +17643,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -18319,7 +18319,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19460,7 +19460,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.enrichments.indicator.url.registered_domain
@@ -19511,7 +19511,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.enrichments.indicator.url.top_level_domain
@@ -20386,7 +20386,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -21062,7 +21062,7 @@ threat:
         change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).'
+        are available here: https://github.com/elastic/toutoumomoma'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -22219,7 +22219,7 @@ threat:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: threat.indicator.url.registered_domain
@@ -22270,7 +22270,7 @@ threat:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: threat.indicator.url.top_level_domain
@@ -24072,7 +24072,7 @@ url:
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: url.registered_domain
@@ -24120,7 +24120,7 @@ url:
         for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
-        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        list (https://publicsuffix.org). Trying to approximate this by simply taking
         the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
       flat_name: url.top_level_domain
@@ -25270,8 +25270,7 @@ vulnerability:
       dashed_name: vulnerability-category
       description: 'The type of system or architecture that the vulnerability affects.
         These may be platform-specific (for example, Debian or SUSE) or general (for
-        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
-        vulnerability categories])
+        example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.'
       example: '["Firewall"]'
@@ -25298,8 +25297,7 @@ vulnerability:
     vulnerability.description:
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
-        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
-        Vulnerabilities and Exposure CVE description])
+        of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       flat_name: vulnerability.description
       ignore_above: 1024
@@ -25328,8 +25326,7 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
-        and Exposure CVE ID])
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -97,7 +97,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -111,7 +111,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -92,7 +92,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -106,7 +106,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -122,7 +122,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -136,7 +136,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -70,7 +70,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/macho.yml
+++ b/schemas/macho.yml
@@ -41,7 +41,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -86,7 +86,7 @@
         code-level transformations have occurred, which would change more traditional hash values.
 
         The algorithm used to calculate the Go symbol hash and a reference implementation
-        are available [here](https://github.com/elastic/toutoumomoma).
+        are available here: https://github.com/elastic/toutoumomoma
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -97,7 +97,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -111,7 +111,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -99,7 +99,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -113,7 +113,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -96,7 +96,7 @@
         For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: example.com
 
@@ -110,7 +110,7 @@
         For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
-        suffix list (http://publicsuffix.org). Trying to approximate this by
+        suffix list (https://publicsuffix.org). Trying to approximate this by
         simply taking the last label will not work well for effective TLDs such as "co.uk".
       example: co.uk
 

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -118,7 +118,7 @@
         The type of system or architecture that the vulnerability affects. These may be
         platform-specific (for example, Debian or SUSE) or general (for example, Database
         or Firewall).
-        For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys vulnerability categories])
+        For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm)
 
         This field must be an array.
 
@@ -136,7 +136,7 @@
       description: >
         The description of the vulnerability that provides additional context of the
         vulnerability.
-        For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+        For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created)
 
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
 
@@ -147,7 +147,7 @@
       description: >
         The identification (ID) is the number portion of a vulnerability entry. It
         includes a unique identification number for the vulnerability.
-        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
+        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)
 
       example: CVE-2019-00001
 


### PR DESCRIPTION
## Description

- Removed link text markup, causes issues since final rendering of docs can be in either markdown or asciidoc
- Replace http with https in links