### PR TITLE
Increase url.query ignore_above value to 2083 (#2424)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,9 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Increase ignore_above value for url.query. #2424
+
+#### Deprecated
 
 ### Tooling and Artifact Changes
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2325,7 +2325,7 @@
     - name: url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'URL linking to an external system to continue investigation of
         this event.
 
@@ -10372,7 +10372,7 @@
     - name: enrichments.indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -12005,7 +12005,7 @@
     - name: indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -13068,7 +13068,7 @@
     - name: query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3809,7 +3809,7 @@ event.url:
     are a common use case for this field.'
   example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
   flat_name: event.url
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: url
   normalize: []
@@ -16817,7 +16817,7 @@ threat.enrichments.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.enrichments.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -19568,7 +19568,7 @@ threat.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -21299,7 +21299,7 @@ url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4828,7 +4828,7 @@ event:
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       flat_name: event.url
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: url
       normalize: []
@@ -19526,7 +19526,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.enrichments.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -22285,7 +22285,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -24139,7 +24139,7 @@ url:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []

--- a/experimental/generated/elasticsearch/composable/component/event.json
+++ b/experimental/generated/elasticsearch/composable/component/event.json
@@ -101,7 +101,7 @@
               "type": "keyword"
             },
             "url": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             }
           }

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -731,7 +731,7 @@
                           "type": "long"
                         },
                         "query": {
-                          "ignore_above": 1024,
+                          "ignore_above": 2083,
                           "type": "keyword"
                         },
                         "registered_domain": {
@@ -1664,7 +1664,7 @@
                       "type": "long"
                     },
                     "query": {
-                      "ignore_above": 1024,
+                      "ignore_above": 2083,
                       "type": "keyword"
                     },
                     "registered_domain": {

--- a/experimental/generated/elasticsearch/composable/component/url.json
+++ b/experimental/generated/elasticsearch/composable/component/url.json
@@ -47,7 +47,7 @@
               "type": "long"
             },
             "query": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             },
             "registered_domain": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1318,7 +1318,7 @@
             "type": "keyword"
           },
           "url": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           }
         }
@@ -5988,7 +5988,7 @@
                         "type": "long"
                       },
                       "query": {
-                        "ignore_above": 1024,
+                        "ignore_above": 2083,
                         "type": "keyword"
                       },
                       "registered_domain": {
@@ -6921,7 +6921,7 @@
                     "type": "long"
                   },
                   "query": {
-                    "ignore_above": 1024,
+                    "ignore_above": 2083,
                     "type": "keyword"
                   },
                   "registered_domain": {
@@ -7541,7 +7541,7 @@
             "type": "long"
           },
           "query": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           },
           "registered_domain": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2275,7 +2275,7 @@
     - name: url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'URL linking to an external system to continue investigation of
         this event.
 
@@ -10322,7 +10322,7 @@
     - name: enrichments.indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -11955,7 +11955,7 @@
     - name: indicator.url.query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 
@@ -13018,7 +13018,7 @@
     - name: query
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 2083
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3740,7 +3740,7 @@ event.url:
     are a common use case for this field.'
   example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
   flat_name: event.url
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: url
   normalize: []
@@ -16748,7 +16748,7 @@ threat.enrichments.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.enrichments.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -19499,7 +19499,7 @@ threat.indicator.url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: threat.indicator.url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []
@@ -21230,7 +21230,7 @@ url.query:
     empty string. The `exists` query can be used to differentiate between the two
     cases.'
   flat_name: url.query
-  ignore_above: 1024
+  ignore_above: 2083
   level: extended
   name: query
   normalize: []

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4748,7 +4748,7 @@ event:
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       flat_name: event.url
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: url
       normalize: []
@@ -19446,7 +19446,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.enrichments.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -22205,7 +22205,7 @@ threat:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: threat.indicator.url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []
@@ -24059,7 +24059,7 @@ url:
         with an empty string. The `exists` query can be used to differentiate between
         the two cases.'
       flat_name: url.query
-      ignore_above: 1024
+      ignore_above: 2083
       level: extended
       name: query
       normalize: []

--- a/generated/elasticsearch/composable/component/event.json
+++ b/generated/elasticsearch/composable/component/event.json
@@ -101,7 +101,7 @@
               "type": "keyword"
             },
             "url": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             }
           }

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -731,7 +731,7 @@
                           "type": "long"
                         },
                         "query": {
-                          "ignore_above": 1024,
+                          "ignore_above": 2083,
                           "type": "keyword"
                         },
                         "registered_domain": {
@@ -1664,7 +1664,7 @@
                       "type": "long"
                     },
                     "query": {
-                      "ignore_above": 1024,
+                      "ignore_above": 2083,
                       "type": "keyword"
                     },
                     "registered_domain": {

--- a/generated/elasticsearch/composable/component/url.json
+++ b/generated/elasticsearch/composable/component/url.json
@@ -47,7 +47,7 @@
               "type": "long"
             },
             "query": {
-              "ignore_above": 1024,
+              "ignore_above": 2083,
               "type": "keyword"
             },
             "registered_domain": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1276,7 +1276,7 @@
             "type": "keyword"
           },
           "url": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           }
         }
@@ -5946,7 +5946,7 @@
                         "type": "long"
                       },
                       "query": {
-                        "ignore_above": 1024,
+                        "ignore_above": 2083,
                         "type": "keyword"
                       },
                       "registered_domain": {
@@ -6879,7 +6879,7 @@
                     "type": "long"
                   },
                   "query": {
-                    "ignore_above": 1024,
+                    "ignore_above": 2083,
                     "type": "keyword"
                   },
                   "registered_domain": {
@@ -7499,7 +7499,7 @@
             "type": "long"
           },
           "query": {
-            "ignore_above": 1024,
+            "ignore_above": 2083,
             "type": "keyword"
           },
           "registered_domain": {

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -819,6 +819,7 @@
     - name: url
       level: extended
       type: keyword
+      ignore_above: 2083
       short: Event investigation URL
       description: >
         URL linking to an external system to continue investigation of this event.

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -155,6 +155,7 @@
         no `?`, there is no query field. If there is a `?` but no query,
         the query field exists with an empty string. The `exists`
         query can be used to differentiate between the two cases.
+      ignore_above: 2083
 
     - name: extension
       level: extended


### PR DESCRIPTION
Increasing the url.query ignore_above value will allow indexing longer query values which have been observed.

2083 is used because it will cover the maximum url length for Chrome (2048) and Internet Explorer (2083).

Other browsers and web servers support longer URLs, and there is no absolute URL limit defined in any RFC. So higher values could be possible, supporting Chrome's maximum length will allow compatibility with the most common browser, while not increasing the index size too much.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? y
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. n/a
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? y
