### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/ecs-converting.md
+++ b/docs/reference/ecs-converting.md
@@ -129,10 +129,8 @@ If the `destination field` is `@timestamp`, a `format_action` of `parse_timestam
 
 4. In {{kib}}, open the main menu and click **Stack Management > Ingest Pipelines > Create pipeline > New pipeline from CSV**.
 
-   :::{image} images/kib-create-pipeline-from-csv.png
-   :alt: Create Pipeline from CSV in Kibana
-   :class: screenshot
-   :::
+   % TO DO: Use `:class: screenshot`
+   ![Create Pipeline from CSV in Kibana](images/kib-create-pipeline-from-csv.png)
 
 5. On the **Create pipeline from CSV** page, upload your CSV file.
 6. Under **Default action**, select the **Copy field name** or **Rename field** option.
@@ -147,10 +145,9 @@ If the `destination field` is `@timestamp`, a `format_action` of `parse_timestam
 
    {{kib}} displays a JSON preview of the ingest pipeline generated from your CSV file.
 
-   :::{image} images/kib-create-pipeline-from-csv-preview.png
-   :alt: Preview pipeline from CSV in Kibana
-   :class: screenshot
-   :::
+    % TO DO: Use `:class: screenshot`
+    ![Preview pipeline from CSV in Kibana](images/kib-create-pipeline-from-csv-preview.png)
+
 
 8. To create the pipeline, click **Continue to create pipeline**.
 9. On the **Create pipeline** page, you can add additional ingest processors to your pipeline.


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting?