### PR TITLE
Ensure docs are build for version branches

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '\d+.\d+'
   pull_request_target: ~
   merge_group: ~
 


### PR DESCRIPTION
This is needed to start onboarding `9.0` to the documentation build

https://github.com/elastic/docs-builder/pull/1180

Requires:

https://github.com/elastic/docs-builder/pull/1297
https://github.com/elastic/docs-builder/pull/1299

To be merged before merging and backporting this to `9.0`