### PR TITLE
ECS Release notes: Fix mapped page

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,7 +1,7 @@
 ---
 navigation_title: "ECS"
 mapped_pages:
-  - https://www.elastic.co/guide/en/ecs/current/releasenotes.html
+  - https://www.elastic.co/guide/en/ecs/current/ecs-release-notes.html
 ---
 
 # ECS release notes [ecs-release-notes]


### PR DESCRIPTION
The currently set mapped_page doesn't exist, causing the version dropdown to show only disabled versions.