### PR TITLE
Fix Github workflow to pass correct release tag for typescript generation

### DIFF
--- a/.github/workflows/build_ecs_typescript.yml
+++ b/.github/workflows/build_ecs_typescript.yml
@@ -17,4 +17,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.ECS_TYPESCRIPT_REPO_TRIGGER_KEY }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/elastic/ecs-typescript/actions/workflows/generate.yml/dispatches \
-          -d '{"ref":"main","inputs":{"ecsRef":"${{ env.RELEASE_VERSION }}"}}'
+          -d '{"ref":"main","inputs":{"ecsRef":"${{ github.event.release.tag_name }}"}}'


### PR DESCRIPTION
#### 1. What does this PR do?
The [ECS](https://github.com/elastic/ecs) repository has a [GitHub workflow](https://github.com/elastic/ecs/blob/main/.github/workflows/build_ecs_typescript.yml) that should be triggered on every release. This calls another [workflow](https://github.com/elastic/ecs-typescript/blob/main/.github/workflows/generate.yml) defined in the [ecs-typescript](https://github.com/elastic/ecs-typescript) repository to create a pull request with the related updates for generating TypeScript definitions for the `@elastic/ecs` npm package.

The automation is not working at the moment and it will be fixed as part of this issue.

There are 2 root causes for this to be not working

1. Incorrect `ecfRef` being passed - Instead of `env.RELEASE_VERSION`, it should be `github.event.release.tag_name`
2. Auth issue - `secrets.ECS_TYPESCRIPT_REPO_TRIGGER_KEY` needs to be fixed somehow. I will investigate which team to ask for it


As part of this PR, the 1st issue is being fixed here. Second issue will be fixed directly in the Repo Settings


#### 2. Which ECS fields are affected/introduced?
 NONE


#### 3. Why is this change necessary?

To fix an automation, which never worked


#### 4. Have you added/updated documentation?

Not Required

#### 5. Have you built ECS and committed any newly generated files?
Not Required

#### 6. Have you run the ECS validation tests locally?
Not Required

#### 7. Anything else for the reviewers?
Not Required

---

#### Commit Message
<!-- This will be used as the commit message when merging the PR. Please clearly explain what change is being changed and why. -->

