### PR TITLE
[backport 9.1] Add 9.1.0 release notes to docs (#2544)

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,21 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [ecs-next-fixes]
 % *
 
+## 9.1.0 [ecs-9-1-0-release-notes]
+
+### Features and enhancements [ecs-9-1-0-features-enhancements]
+
+* Add `gen_ai` fields to schema as beta. [#2475](https://github.com/elastic/ecs/pull/2475)
+* Allow Unicode characters in generated ECS yml files. [#2478](https://github.com/elastic/ecs/pull/2478)
+* Update semconv version used in file generation to v1.34.0 [#2483](https://github.com/elastic/ecs/pull/2483)
+
+### Fixes [ecs-9-1-0-fixes]
+
+* Add `origin_referrer_url` and `origin_url` fields, which indicate the origin information to the file, process and dll schemas [#2441](https://github.com/elastic/ecs/pull/2441)
+* Add `thumbprint_sha256` to `code_signature` schema. [#2452](https://github.com/elastic/ecs/pull/2452)
+* Fix otel urls for fieldsets with underscores. [#2486](https://github.com/elastic/ecs/pull/2486)
+
+
 ## 9.0.0 [ecs-9-0-0-release-notes]
 
 ### Features and enhancements [ecs-9-0-0-features-enhancements]


### PR DESCRIPTION
Backport 9.1.0 release notes into the 9.1 branch.