### PR TITLE
Documentation correction of wrong event name in source and destination fields table

### DIFF
--- a/docs/reference/ecs-mapping-network-events.md
+++ b/docs/reference/ecs-mapping-network-events.md
@@ -109,7 +109,7 @@ It’s important to note that while the values for the `source` and `destination
 | --- | --- | --- |
 | 192.168.86.222 | 192.168.86.1 | DNS query request 1 |
 | 192.168.86.1 | 192.168.86.222 | DNS answer response 1 |
-| 192.168.86.42 | 192.168.86.1 | DNS answer request 2 |
+| 192.168.86.42 | 192.168.86.1 | DNS query request 2 |
 | 192.168.86.1 | 192.168.86.42 | DNS answer request 2 |
 
 | client.ip | server.ip | event |


### PR DESCRIPTION
This is only a documentation correction of the wrong event name in the first table that should be "DNS query request 2" instead of "DNS answer request 2".


