### PR TITLE
Fix Jekyll build failure caused by Jinja2 syntax in scripts/docs/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+# Exclude internal tooling and developer documentation from the Jekyll site build.
+# Without this, Jekyll's Liquid engine tries to process Jinja2 {% %} tags in
+# scripts/docs/*.md and crashes with "Unknown tag" errors.
+exclude:
+  - scripts/
+  - venv/
+  - generated/
+  - experimental/
+  - "*.py"
+  - Makefile


### PR DESCRIPTION
## Summary

The GitHub Pages build on `main` has been failing since #2569 landed, which added `scripts/docs/markdown-generator.md`. That file contains Jinja2 template syntax (e.g. `{% macro %}`) inside fenced code blocks. Jekyll's Liquid engine processes `{% %}` delimiters even inside code blocks, and `macro` is not a valid Liquid tag, causing the build to crash with: `Liquid syntax error (line 189): Unknown tag 'macro'`

## Fix

Add a `_config.yml` at the repo root that excludes `scripts/` (and other internal directories like `venv/`, `generated/`, `experimental/`) from Jekyll processing. These directories contain internal developer tooling that was never intended to be published as part of the GitHub Pages site.

## Test plan

Confirm the GitHub Pages build job passes on `main` after merge

> **Note:** The `pages-build-deployment` workflow is GitHub's auto-generated Pages workflow and only runs on pushes to `main` — it has no PR trigger. This fix cannot be validated by CI before merge.

Sample broken build: https://github.com/elastic/ecs/actions/runs/23446341689/job/68211045270