### PR TITLE
[Agent Skills] Add agent skills and rules for ECS PR Triage

### DIFF
--- a/.agents/rules/ecs-contribution-routing.mdc
+++ b/.agents/rules/ecs-contribution-routing.mdc
@@ -1,0 +1,26 @@
+---
+description: ECS contribution routing — direct PR vs RFC and OTel alignment context
+alwaysApply: true
+---
+
+# ECS contribution routing
+
+## Two paths
+
+- **Direct PR** — Minor, non-controversial work: bugfixes, small additive changes to existing fieldsets that follow established patterns, tooling, tests, CI, hand-authored docs (not generated reference), `CHANGELOG.next.md`.
+- **RFC (Proposal)** — Substantial or risky work per [rfcs/README.md](rfcs/README.md): breaking changes for the next major, **new top-level fieldsets** (`schemas/<new>.yml`), **new fields for an unaddressed use case**, or changes that **alter ECS scope**. During OTel donation, anything that may be controversial or hard to align with semantic conventions should also use RFC.
+
+## Authoritative docs
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — workflow, `make` / `make test` / `make check`, changelogs, OTel `otel:` blocks.
+- [rfcs/PROCESS.md](rfcs/PROCESS.md) — single **Proposal** stage, target maturity (alpha/beta), committee questions.
+- [rfcs/0000-rfc-template.md](rfcs/0000-rfc-template.md) — required sections; remove template comments when done.
+- [schemas/README.md](schemas/README.md) — field and field set YAML rules.
+
+## OTel donation period
+
+Schema changes should consider eventual OTel alignment: naming, types, overlaps. Propose parallel changes in [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions) when appropriate; OTel PR need not merge first. New/changed fields that relate to semconv need correct `otel:` metadata (see CONTRIBUTING).
+
+## Triage default
+
+When in doubt between direct PR and RFC, **prefer RFC** or flag **needs maintainer discussion** rather than under-scoping review.

--- a/.agents/rules/ecs-contribution-routing.mdc
+++ b/.agents/rules/ecs-contribution-routing.mdc
@@ -8,7 +8,7 @@ alwaysApply: true
 ## Two paths
 
 - **Direct PR** — Minor, non-controversial work: bugfixes, small additive changes to existing fieldsets that follow established patterns, tooling, tests, CI, hand-authored docs (not generated reference), `CHANGELOG.next.md`.
-- **RFC (Proposal)** — Substantial or risky work per [rfcs/README.md](rfcs/README.md): breaking changes for the next major, **new top-level fieldsets** (`schemas/<new>.yml`), **new fields for an unaddressed use case**, or changes that **alter ECS scope**. During OTel donation, anything that may be controversial or hard to align with semantic conventions should also use RFC.
+- **RFC (Proposal)** — Substantial or risky work per [rfcs/README.md](rfcs/README.md): breaking changes for the next major, **new top-level fieldsets** (`schemas/<new>.yml`), **new fields for an unaddressed use case**, or changes that **alter ECS scope**.
 
 ## Authoritative docs
 

--- a/.agents/rules/ecs-contribution-routing.mdc
+++ b/.agents/rules/ecs-contribution-routing.mdc
@@ -1,5 +1,5 @@
 ---
-description: ECS contribution routing — direct PR vs RFC and OTel alignment context
+description: ECS contribution routing — direct PR vs RFC
 alwaysApply: true
 ---
 
@@ -17,9 +17,9 @@ alwaysApply: true
 - [rfcs/0000-rfc-template.md](rfcs/0000-rfc-template.md) — required sections; remove template comments when done.
 - [schemas/README.md](schemas/README.md) — field and field set YAML rules.
 
-## OTel donation period
+## OTel alignment
 
-Schema changes should consider eventual OTel alignment: naming, types, overlaps. Propose parallel changes in [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions) when appropriate; OTel PR need not merge first. New/changed fields that relate to semconv need correct `otel:` metadata (see CONTRIBUTING).
+Schema changes should consider eventual OTel alignment: naming, types, overlaps. New/changed fields that relate to semconv need correct `otel:` metadata (see CONTRIBUTING).
 
 ## Triage default
 

--- a/.agents/rules/ecs-pr-completeness.mdc
+++ b/.agents/rules/ecs-pr-completeness.mdc
@@ -1,0 +1,33 @@
+---
+description: ECS PR review — template, changelog, generated artifacts, CLA
+alwaysApply: false
+---
+
+# ECS PR completeness (review checklist)
+
+Use when reviewing or preparing a PR. Cross-check [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Description & process
+
+- [ ] All PR template sections answered (what, fields affected, why, docs, built ECS, tests, notes).
+- [ ] Links to issues / related PRs where applicable.
+- [ ] **Routing**: If change is substantial (new fieldset, breaking, novel use case), contributor followed [rfcs/PROCESS.md](rfcs/PROCESS.md) — not only a direct schema PR.
+
+## Changelog
+
+- [ ] Entry in [CHANGELOG.next.md](CHANGELOG.next.md) under **Schema Changes** or **Tooling and Artifact Changes**, correct subsection, ordered by PR id, with `#NNNN` link.
+
+## Schema / generator
+
+- [ ] Schema edits only under `schemas/` (and RFC `rfcs/text/` when in RFC flow) — not hand-editing `generated/` or generated field reference markdown.
+- [ ] `make` run; regenerated outputs committed if changed.
+- [ ] `make test` and `make check` pass locally (CI runs `make check` and yamllint).
+
+## Field quality
+
+- [ ] New/changed fields: descriptions, examples, `level`, types; `short` where needed; `otel:` where OTel-related.
+- [ ] No avoidable `object`/`flattened` without justification (see [schemas/README.md](schemas/README.md)).
+
+## Legal
+
+- [ ] Contributor has signed the Elastic CLA when required.

--- a/.agents/rules/ecs-schema-standards.mdc
+++ b/.agents/rules/ecs-schema-standards.mdc
@@ -1,0 +1,35 @@
+---
+description: ECS schema YAML — field set and field attributes, OTel, strict mode
+globs: schemas/**/*.yml
+alwaysApply: false
+---
+
+# ECS `schemas/*.yml` standards
+
+## Field set (top-level item)
+
+Required: `name`, `title`, `description`, `type: group`, `fields`.  
+Optional: `short`, `root` (only `base` uses `true`), `group` (sorting), `reusable`, `short_override`, `alpha` / `beta` (mutually exclusive at field set and per-field).
+
+## Each field
+
+Required: `name`, `level` (`core` | `extended`), `type`, `description`.  
+Optional: `short` (single line; if description has multiple paragraphs, `short` is required), `example`, `required` (rare; only `@timestamp`, `ecs.version` today), `multi_fields`, `index`, `format`, `pattern`, `expected_values`, `allowed_values`, `normalize`, `alpha` / `beta`, `otel`, `path` (for `type: alias`).
+
+## `object` / `flattened`
+
+- `object` without child fields: only for opaque, homogeneous shapes (e.g. string-key/string-value like `labels`). Otherwise define explicit leaf fields.
+- `flattened`: arbitrary/unbounded keys (e.g. headers); weaker typing. If subfields are semantically queryable, model them explicitly.
+
+## OTel (`otel:`)
+
+List of mappings; each needs `relation`: `match`, `equivalent`, `related`, `conflict`, `metric`, `otlp`, `na`. Follow required keys per relation in [CONTRIBUTING.md](CONTRIBUTING.md). Intentionally unmapped fields that collide by name with OTel may need `relation: na` to silence generator warnings.
+
+## CI strict mode (`make` / `generator.py --strict`)
+
+- `short` ≤ 120 characters, single line.
+- Composite `example` values (arrays/objects) must be quoted YAML strings.
+- If `pattern` is set, `example` must match.
+- If `expected_values` is set, `example` must be consistent with allowed values.
+
+After edits: run `make` and commit `generated/` and generated `docs/reference/` as required by the repo.

--- a/.agents/skills/ecs-pr-triage/SKILL.md
+++ b/.agents/skills/ecs-pr-triage/SKILL.md
@@ -48,7 +48,7 @@ Assign labels:
 Evaluate against the checklist in [ecs-pr-completeness rule](../../rules/ecs-pr-completeness.mdc):
 
 - PR description: all 7 template sections answered (not empty/placeholder).
-- `CHANGELOG.next.md` entry present, in the correct section (Schema Changes vs Tooling and Artifact Changes), includes `#NNNN`.
+- `CHANGELOG.next.md` entry: **only expected when `schemas/` or `scripts/` files change** (i.e. schema changes or tooling changes). RFC-only PRs (`rfcs/` only), pure documentation PRs, and CI-only PRs do not require a changelog entry. When required, verify it is in the correct section (Schema Changes vs Tooling and Artifact Changes) and includes `#NNNN`.
 - If schema change: `generated/` and `docs/reference/` artifacts present in the diff (evidence that `make` was run and outputs committed).
 - If new/changed fields relate to OTel semconv: `otel:` metadata present on those fields.
 - No hand-edits to files that should only be generator output (`docs/reference/ecs-*.md`, `generated/`).

--- a/.agents/skills/ecs-pr-triage/SKILL.md
+++ b/.agents/skills/ecs-pr-triage/SKILL.md
@@ -25,6 +25,7 @@ From the PR context available to you (or fetched via `gh pr view`, `gh pr diff`,
   - `docs/` — hand-authored docs vs generated reference (`docs/reference/ecs-*.md`)
   - `rfcs/` — RFC markdown and supporting YAML
   - `.github/` — CI workflows, templates, issue config
+  - `release/` — release-process artifacts: `version` file, `CHANGELOG.md` rotation, release-note shuffling in `docs/`
   - Root config — `Makefile`, `version`, `CHANGELOG.next.md`, etc.
 - **PR description body** — check which of the 7 template sections from `.github/PULL_REQUEST_TEMPLATE.md` are filled vs empty/placeholder.
 - **Diff content** — scan for signals: new field set files, field removals, `type:` changes, new `reusable` entries, `allowed_values` additions, `alpha`/`beta` changes, etc.
@@ -33,6 +34,7 @@ From the PR context available to you (or fetched via `gh pr view`, `gh pr diff`,
 
 Walk the decision tree in [classification-rules.md](classification-rules.md) **in priority order**:
 
+0. **Check for release process PR first** — if the PR exclusively touches release mechanics (version bumps, changelog rotation, moving/updating release notes in `docs/`, `CHANGELOG.md` consolidation) it is always **Direct PR**. Release PRs never require an RFC or discussion regardless of how many files change.
 1. **Check §1 (RFC triggers)** — any match means classification is **Needs RFC**.
    Triggers: new `schemas/*.yml` file, breaking changes (field removal, type change, semantic redefinition), new reuse topology, novel use case, ECS-wide scope, >10 new leaf fields.
 2. **Check §3 (ambiguous)** — any match (without §1) means classification is **Needs Discussion**.
@@ -48,7 +50,7 @@ Assign labels:
 Evaluate against the checklist in [ecs-pr-completeness rule](../../rules/ecs-pr-completeness.mdc):
 
 - PR description: all 7 template sections answered (not empty/placeholder).
-- `CHANGELOG.next.md` entry: **only expected when `schemas/` or `scripts/` files change** (i.e. schema changes or tooling changes). RFC-only PRs (`rfcs/` only), pure documentation PRs, and CI-only PRs do not require a changelog entry. When required, verify it is in the correct section (Schema Changes vs Tooling and Artifact Changes) and includes `#NNNN`.
+- `CHANGELOG.next.md` entry: **only expected when `schemas/` or `scripts/` files change** (i.e. schema changes or tooling changes). RFC-only PRs (`rfcs/` only), pure documentation PRs, CI-only PRs, and **release process PRs** do not require a changelog entry. When required, verify it is in the correct section (Schema Changes vs Tooling and Artifact Changes) and includes `#NNNN`.
 - If schema change: `generated/` and `docs/reference/` artifacts present in the diff (evidence that `make` was run and outputs committed).
 - If new/changed fields relate to OTel semconv: `otel:` metadata present on those fields.
 - No hand-edits to files that should only be generator output (`docs/reference/ecs-*.md`, `generated/`).

--- a/.agents/skills/ecs-pr-triage/SKILL.md
+++ b/.agents/skills/ecs-pr-triage/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: ecs-pr-triage
 description: >-
-  Auto-triggered on every new ECS pull request via GitHub Actions. Analyzes the
-  PR diff and metadata already available in context, classifies the change
-  (schema / tooling / docs / mixed), routes it to the correct contribution path
-  (direct PR vs RFC Proposal vs needs-discussion), checks PR completeness, and
-  produces a structured Triage Report.
+  Triages an ECS pull request. Analyzes the PR diff and metadata, classifies the
+  change (schema / tooling / docs / mixed), routes it to the correct contribution
+  path (direct PR vs RFC Proposal vs needs-discussion), checks PR completeness,
+  and produces a structured Triage Report.
 ---
 
-# ECS PR triage (autonomous agent)
+# ECS PR triage
 
-This skill runs **automatically** on each incoming PR — there is no user prompt. The GitHub Actions workflow provides the PR diff, changed file list, PR description, and metadata as context. The agent analyzes that context, makes a routing decision, and delivers a triage report.
+This skill triages an ECS pull request. It can be invoked manually, by CI, or by any other automation. The agent needs access to the PR diff, changed file list, PR description, and metadata — either already present in context or fetched via tools (e.g. `gh`). It analyzes that context, makes a routing decision, and delivers a triage report.
 
 ## Execution steps
 
 ### 1. Inventory the PR context
 
-From the PR context already available to you, extract:
+From the PR context available to you (or fetched via `gh pr view`, `gh pr diff`, etc.), extract:
 
 - **PR number, title, author.**
 - **Changed file paths** — bucket every path into one of these categories:

--- a/.agents/skills/ecs-pr-triage/SKILL.md
+++ b/.agents/skills/ecs-pr-triage/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # ECS PR triage
 
-This skill triages an ECS pull request. It can be invoked manually, by CI, or by any other automation. The agent needs access to the PR diff, changed file list, PR description, and metadata — either already present in context or fetched via tools (e.g. `gh`). It analyzes that context, makes a routing decision, and delivers a triage report.
+This skill triages an ECS pull request. The agent needs access to the PR diff, changed file list, PR description, and metadata — either already present in context or fetched via tools (e.g. `gh`). It analyzes that context, makes a routing decision, and delivers a triage report.
 
 ## Execution steps
 
@@ -52,7 +52,7 @@ Evaluate against the checklist in [ecs-pr-completeness rule](../../rules/ecs-pr-
 - PR description: all 7 template sections answered (not empty/placeholder).
 - `CHANGELOG.next.md` entry: **only expected when `schemas/` or `scripts/` files change** (i.e. schema changes or tooling changes). RFC-only PRs (`rfcs/` only), pure documentation PRs, CI-only PRs, and **release process PRs** do not require a changelog entry. When required, verify it is in the correct section (Schema Changes vs Tooling and Artifact Changes) and includes `#NNNN`.
 - If schema change: `generated/` and `docs/reference/` artifacts present in the diff (evidence that `make` was run and outputs committed).
-- If new/changed fields relate to OTel semconv: `otel:` metadata present on those fields.
+- If new/changed fields relate to OTel semconv: `otel:` metadata is encouraged but not required.
 - No hand-edits to files that should only be generator output (`docs/reference/ecs-*.md`, `generated/`).
 
 Mark each item as **met** or **missing**.
@@ -76,7 +76,7 @@ Fill [report-template.md](report-template.md) completely. Rules:
 - **Source of truth for fields:** `schemas/*.yml`. Hand-edits to `generated/` or `docs/reference/ecs-*.md` without a corresponding schema change are errors — flag them.
 - **Build pipeline:** `make` regenerates all artifacts; `make test` runs unit tests; `make check` runs generate + test + diff (CI parity).
 - **RFC process:** single Proposal stage per `rfcs/PROCESS.md`; template at `rfcs/0000-rfc-template.md`.
-- **OTel donation:** new semconv-related fields need `otel:` metadata per `CONTRIBUTING.md`.
+- **OTel mapping:** `otel:` metadata on fields is optional; encouraged when a clear semconv counterpart exists but not a merge gate.
 
 ## Related assets
 

--- a/.agents/skills/ecs-pr-triage/SKILL.md
+++ b/.agents/skills/ecs-pr-triage/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ecs-pr-triage
+description: >-
+  Auto-triggered on every new ECS pull request via GitHub Actions. Analyzes the
+  PR diff and metadata already available in context, classifies the change
+  (schema / tooling / docs / mixed), routes it to the correct contribution path
+  (direct PR vs RFC Proposal vs needs-discussion), checks PR completeness, and
+  produces a structured Triage Report.
+---
+
+# ECS PR triage (autonomous agent)
+
+This skill runs **automatically** on each incoming PR — there is no user prompt. The GitHub Actions workflow provides the PR diff, changed file list, PR description, and metadata as context. The agent analyzes that context, makes a routing decision, and delivers a triage report.
+
+## Execution steps
+
+### 1. Inventory the PR context
+
+From the PR context already available to you, extract:
+
+- **PR number, title, author.**
+- **Changed file paths** — bucket every path into one of these categories:
+  - `schemas/` — source schema YAML (the key signal for routing)
+  - `generated/` — build outputs (should only change as a side effect of schema + `make`)
+  - `scripts/` — generator tooling, tests, templates
+  - `docs/` — hand-authored docs vs generated reference (`docs/reference/ecs-*.md`)
+  - `rfcs/` — RFC markdown and supporting YAML
+  - `.github/` — CI workflows, templates, issue config
+  - Root config — `Makefile`, `version`, `CHANGELOG.next.md`, etc.
+- **PR description body** — check which of the 7 template sections from `.github/PULL_REQUEST_TEMPLATE.md` are filled vs empty/placeholder.
+- **Diff content** — scan for signals: new field set files, field removals, `type:` changes, new `reusable` entries, `allowed_values` additions, `alpha`/`beta` changes, etc.
+
+### 2. Classify the change
+
+Walk the decision tree in [classification-rules.md](classification-rules.md) **in priority order**:
+
+1. **Check §1 (RFC triggers)** — any match means classification is **Needs RFC**.
+   Triggers: new `schemas/*.yml` file, breaking changes (field removal, type change, semantic redefinition), new reuse topology, novel use case, ECS-wide scope, >10 new leaf fields.
+2. **Check §3 (ambiguous)** — any match (without §1) means classification is **Needs Discussion**.
+   Includes: 3–10 new fields in one field set, new `allowed_values` on categorization fields (`event.category`, `event.type`, `event.kind`), maturity promotions, unjustified `object`/`flattened`.
+3. **Otherwise §2** — all remaining low-risk patterns → classification is **Direct PR**.
+
+Assign labels:
+- **Change type:** `Schema Change` | `Tooling` | `Documentation` | `Mixed`
+- **Scope:** `Minor` | `Moderate` | `Substantial`
+
+### 3. Check completeness
+
+Evaluate against the checklist in [ecs-pr-completeness rule](../../rules/ecs-pr-completeness.mdc):
+
+- PR description: all 7 template sections answered (not empty/placeholder).
+- `CHANGELOG.next.md` entry present, in the correct section (Schema Changes vs Tooling and Artifact Changes), includes `#NNNN`.
+- If schema change: `generated/` and `docs/reference/` artifacts present in the diff (evidence that `make` was run and outputs committed).
+- If new/changed fields relate to OTel semconv: `otel:` metadata present on those fields.
+- No hand-edits to files that should only be generator output (`docs/reference/ecs-*.md`, `generated/`).
+
+Mark each item as **met** or **missing**.
+
+### 4. Produce the triage report
+
+Fill [report-template.md](report-template.md) completely. Rules:
+
+- **Cite specific triggers.** E.g. "New file `schemas/foo.yml` detected → RFC required per classification-rules §1."
+- **List every missing checklist item** with clear remediation (e.g. "Add a `CHANGELOG.next.md` entry under Schema Changes > Added with `#NNNN`").
+- **If Needs RFC:** point the contributor to `rfcs/PROCESS.md` and the RFC template at `rfcs/0000-rfc-template.md`. Reference the **ecs-rfc-guide** skill for a detailed walkthrough.
+- **If Needs Discussion:** state exactly what is ambiguous and what a maintainer should weigh in on.
+
+## Decision defaults
+
+- **Conservative:** when borderline, prefer **Needs Discussion** or **Needs RFC** over **Direct PR**. Under-triaging is worse than over-triaging.
+- **No approval authority:** the agent triages and reports. It does not approve, request changes, or merge.
+
+## Important repo facts
+
+- **Source of truth for fields:** `schemas/*.yml`. Hand-edits to `generated/` or `docs/reference/ecs-*.md` without a corresponding schema change are errors — flag them.
+- **Build pipeline:** `make` regenerates all artifacts; `make test` runs unit tests; `make check` runs generate + test + diff (CI parity).
+- **RFC process:** single Proposal stage per `rfcs/PROCESS.md`; template at `rfcs/0000-rfc-template.md`.
+- **OTel donation:** new semconv-related fields need `otel:` metadata per `CONTRIBUTING.md`.
+
+## Related assets
+
+- [classification-rules.md](classification-rules.md) — full decision tree with thresholds and examples.
+- [report-template.md](report-template.md) — output format to fill.
+- [ecs-rfc-guide skill](../ecs-rfc-guide/SKILL.md) — reference for contributors when RFC is needed.
+- Rules: [ecs-contribution-routing](../../rules/ecs-contribution-routing.mdc), [ecs-schema-standards](../../rules/ecs-schema-standards.mdc), [ecs-pr-completeness](../../rules/ecs-pr-completeness.mdc).

--- a/.agents/skills/ecs-pr-triage/classification-rules.md
+++ b/.agents/skills/ecs-pr-triage/classification-rules.md
@@ -11,7 +11,7 @@ Use after inspecting the diff (files touched, approximate size, semantics). See 
 | New reuse topology | New `reusable.expected` entries that introduce nesting in new places (e.g. new `{at, as}` role) |
 | Novel / unaddressed use case | Domain or signal type not clearly covered by existing field sets; “we need a place for X” without an obvious existing home |
 | ECS-wide scope | Changes to core taxonomy (`event.*` categorization), compliance story, or conventions affecting most integrations |
-| Large batch | Rough heuristic: **> ~10** new leaf fields in one PR (especially across concepts) — treat as substantial unless clearly trivial mirrors of semconv |
+| Large batch | Rough heuristic: **> ~10** new leaf fields in one PR (especially across concepts) — treat as substantial unless clearly trivial changes |
 
 ## 2. Direct PR OK (typically **Direct PR**)
 

--- a/.agents/skills/ecs-pr-triage/classification-rules.md
+++ b/.agents/skills/ecs-pr-triage/classification-rules.md
@@ -1,0 +1,52 @@
+# ECS PR classification — decision rules
+
+Use after inspecting the diff (files touched, approximate size, semantics). See [rfcs/README.md](../../../rfcs/README.md) and [CONTRIBUTING.md](../../../CONTRIBUTING.md) for project wording.
+
+## 1. RFC required (any match → **Needs RFC**)
+
+| Trigger | Examples / notes |
+|--------|-------------------|
+| New top-level field set | New `schemas/<name>.yml` (new `name:` at field-set level) |
+| Breaking change | Removing fields; changing `type`; narrowing/breaking semantics; moving fields; `extended` → `core` promotions; incompatible `allowed_values` / categorization |
+| New reuse topology | New `reusable.expected` entries that introduce nesting in new places (e.g. new `{at, as}` role) |
+| Novel / unaddressed use case | Domain or signal type not clearly covered by existing field sets; “we need a place for X” without an obvious existing home |
+| ECS-wide scope | Changes to core taxonomy (`event.*` categorization), compliance story, or conventions affecting most integrations |
+| Large batch | Rough heuristic: **> ~10** new leaf fields in one PR (especially across concepts) — treat as substantial unless clearly trivial mirrors of semconv |
+
+## 2. Direct PR OK (typically **Direct PR**)
+
+All should be low controversy and incremental:
+
+| Pattern | Examples |
+|---------|----------|
+| Bugfix / clarity | Typos, wrong examples, description fixes, strict-mode fixes (`short`, quoted examples) |
+| Small additive extension | 1–2 new fields in an **existing** field set that mirror established patterns (e.g. new OTel-aligned attribute in `gen_ai.*`) |
+| Tooling only | `scripts/`, generator templates, tests, Makefile |
+| Non-generated docs | `docs/` that are not generator output (verify path); README, CONTRIBUTING cross-links |
+| Changelog / version housekeeping | `CHANGELOG.next.md`, release-note scaffolding (if consistent with repo practice) |
+| CI / automation | `.github/workflows/` (non-breaking) |
+
+**Caveat:** If a “small” addition introduces **new** semantics (new tool protocol, new entity type), escalate to **Needs RFC** or **Needs Discussion**.
+
+## 3. Needs discussion (maintainer judgment)
+
+Use when not clearly 1 or 2:
+
+| Situation | Why ambiguous |
+|-----------|-----------------|
+| **3–10** new fields in one field set | May be one coherent extension or may need design review |
+| New `allowed_values` on `event.category`, `event.type`, `event.kind`, etc. | Affects categorization and many consumers |
+| Maturity changes | Field set or field `alpha`/`beta` ↔ GA promotions |
+| `object` / `flattened` without children | Requires justification per [schemas/README.md](../../../schemas/README.md) |
+| Deprecation only | May still need communication / version strategy |
+
+## 4. Change type labels
+
+- **Schema Change:** any `schemas/*.yml` or RFC YAML intended for schema.
+- **Tooling:** `scripts/`, `Makefile`, generator tests, templates under `scripts/templates/`.
+- **Documentation:** `docs/` (exclude generated field reference if policy is generator-only — flag direct edits to generated files as errors).
+- **Mixed:** combinations of the above.
+
+## 5. Historical RFCs (orientation only)
+
+Many files under `rfcs/text/` predate the single **Proposal** stage; use them as examples of depth (fields, source data, concerns), not as stage labels. Prefer [rfcs/PROCESS.md](../../../rfcs/PROCESS.md) for current process.

--- a/.agents/skills/ecs-pr-triage/classification-rules.md
+++ b/.agents/skills/ecs-pr-triage/classification-rules.md
@@ -11,7 +11,7 @@ Use after inspecting the diff (files touched, approximate size, semantics). See 
 | New reuse topology | New `reusable.expected` entries that introduce nesting in new places (e.g. new `{at, as}` role) |
 | Novel / unaddressed use case | Domain or signal type not clearly covered by existing field sets; “we need a place for X” without an obvious existing home |
 | ECS-wide scope | Changes to core taxonomy (`event.*` categorization), compliance story, or conventions affecting most integrations |
-| Large batch | Rough heuristic: **> ~10** new leaf fields in one PR (especially across concepts) — treat as substantial unless clearly trivial changes |
+| Large batch | Rough heuristic: **> ~5** new leaf fields in one PR (especially across concepts) — treat as substantial unless clearly trivial changes |
 
 ## 2. Direct PR OK (typically **Direct PR**)
 
@@ -35,7 +35,7 @@ Use when not clearly 1 or 2:
 
 | Situation | Why ambiguous |
 |-----------|-----------------|
-| **3–10** new fields in one field set | May be one coherent extension or may need design review |
+| **3–5** new fields in one field set | May be one coherent extension or may need design review |
 | New `allowed_values` on `event.category`, `event.type`, `event.kind`, etc. | Affects categorization and many consumers |
 | Maturity changes | Field set or field `alpha`/`beta` ↔ GA promotions |
 | `object` / `flattened` without children | Requires justification per [schemas/README.md](../../../schemas/README.md) |

--- a/.agents/skills/ecs-pr-triage/classification-rules.md
+++ b/.agents/skills/ecs-pr-triage/classification-rules.md
@@ -24,6 +24,7 @@ All should be low controversy and incremental:
 | Tooling only | `scripts/`, generator templates, tests, Makefile |
 | Non-generated docs | `docs/` that are not generator output (verify path); README, CONTRIBUTING cross-links |
 | Changelog / version housekeeping | `CHANGELOG.next.md`, release-note scaffolding (if consistent with repo practice) |
+| Release process | Version bumps (`version` file), moving/updating release notes, updating `docs/` release notes, `CHANGELOG` rotation — standard release mechanics |
 | CI / automation | `.github/workflows/` (non-breaking) |
 
 **Caveat:** If a “small” addition introduces **new** semantics (new tool protocol, new entity type), escalate to **Needs RFC** or **Needs Discussion**.

--- a/.agents/skills/ecs-pr-triage/report-template.md
+++ b/.agents/skills/ecs-pr-triage/report-template.md
@@ -31,7 +31,7 @@ Copy and fill in for every triage. Replace bracketed placeholders.
 
 ### Completeness checklist
 - [ ] PR description (all sections)
-- [ ] CHANGELOG.next.md (correct section, `#NNNN`)
+- [ ] CHANGELOG.next.md (only if `schemas/` or `scripts/` changed; correct section, `#NNNN`)
 - [ ] `make` + committed generated outputs (if schema change)
 - [ ] OTel `otel:` on new/changed semconv-related fields
 - [ ] Tests / `make check` (per CONTRIBUTING)

--- a/.agents/skills/ecs-pr-triage/report-template.md
+++ b/.agents/skills/ecs-pr-triage/report-template.md
@@ -1,0 +1,43 @@
+# PR Triage Report template
+
+Copy and fill in for every triage. Replace bracketed placeholders.
+
+```markdown
+## PR Triage Report
+
+**PR:** #[N] — [title]
+**Classification:** Direct PR | Needs RFC | Needs Discussion
+**Change type:** Schema Change | Tooling | Documentation | Mixed
+**Scope:** Minor | Moderate | Substantial
+
+### Summary
+[One short paragraph: what changed and why it matters for routing.]
+
+### Files changed
+- **Schemas:** [list or "none"]
+- **Generated:** [list or "none" — note if missing when schemas changed]
+- **Tooling/scripts/tests:** [list or "none"]
+- **Docs (hand-authored):** [list or "none"]
+- **CI / GitHub:** [list or "none"]
+- **RFCs:** [list or "none"]
+
+### Routing decision
+[Why Direct PR is OK, or why an RFC is required, or what needs maintainer input. Cite specific triggers from classification-rules.md.]
+
+### Risk notes
+- **Breaking / deprecation:** [yes/no + detail]
+- **OTel / semconv:** [alignment, gaps, or N/A]
+- **Scope / reuse:** [new fieldset, reuse, categorization fields, etc.]
+
+### Completeness checklist
+- [ ] PR description (all sections)
+- [ ] CHANGELOG.next.md (correct section, `#NNNN`)
+- [ ] `make` + committed generated outputs (if schema change)
+- [ ] OTel `otel:` on new/changed semconv-related fields
+- [ ] Tests / `make check` (per CONTRIBUTING)
+- [ ] CLA (contributor)
+
+### Recommended next actions
+1. [For contributor or maintainers]
+2. […]
+```

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -49,7 +49,7 @@ When the RFC adds or changes fields:
 
 ## OTel alignment (optional)
 
-ECS does not actively donate fields to OpenTelemetry Semantic Conventions at this time. However, ECS tracks relationships between its fields and OTel semconv via `otel:` metadata tags in `schemas/*.yml`.
+ECS tracks relationships between its fields and OTel semconv via `otel:` metadata tags in `schemas/*.yml`.
 
 - When a new or changed field has a clear OTel semconv counterpart, adding an `otel:` block (with `relation: match | equivalent | related | conflict | na`) is encouraged but **not required**.
 - The `otel:` metadata is used to generate alignment documentation — it is not a gate for merging.

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -22,7 +22,7 @@ Authoritative process: [rfcs/PROCESS.md](../../../rfcs/PROCESS.md). Template: [r
 2. Contributor opens a **PR** that adds the RFC markdown under `rfcs/` (name like `0000-<dash-separated-name>.md` until numbered).
 3. Specify **Target maturity:** `alpha`, `beta`, or `mixture` (see [Field stability](../../../docs/reference/ecs-principles-design.md#_field_stability)).
 4. The PR author assigns the **next available RFC number** (scan `rfcs/text/` for the highest existing number). ECS team reviews holistically and merges on approval.
-5. The RFC PR **must include** the schema changes (`schemas/*.yml`, generated artifacts, docs) at the agreed maturity level — proposal and implementation land together in a single PR.
+5. If applicable, the RFC PR **should include** the schema changes (`schemas/*.yml`, generated artifacts, docs) at the agreed maturity level — proposal and implementation land together in a single PR.
 
 ## Template walkthrough
 

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -3,7 +3,7 @@ name: ecs-rfc-guide
 description: >-
   Guides contributors through the Elastic Common Schema (ECS) RFC (Proposal)
   process: template sections, target maturity (alpha/beta), rfcs/text artifacts,
-  and OTel alignment. Use when a change needs an RFC, when drafting or
+  and optional OTel mapping. Use when a change needs an RFC, when drafting or
   reviewing RFC PRs, or when the user asks how to propose new ECS field sets or
   substantial schema changes.
 ---
@@ -21,8 +21,8 @@ Authoritative process: [rfcs/PROCESS.md](../../../rfcs/PROCESS.md). Template: [r
 1. Single **Proposal** stage — template must keep `Stage: **Proposal**`.
 2. Contributor opens a **PR** that adds the RFC markdown under `rfcs/` (name like `0000-<dash-separated-name>.md` until numbered).
 3. Specify **Target maturity:** `alpha`, `beta`, or `mixture` (see [Field stability](../../../docs/reference/ecs-principles-design.md#_field_stability)).
-4. ECS team reviews holistically; on approval they assign the **RFC number** and merge.
-5. Schema landings at agreed maturity may follow in the same or follow-up PRs (per team practice).
+4. The PR author assigns the **next available RFC number** (scan `rfcs/text/` for the highest existing number). ECS team reviews holistically and merges on approval.
+5. The RFC PR **must include** the schema changes (`schemas/*.yml`, generated artifacts, docs) at the agreed maturity level — proposal and implementation land together in a single PR.
 
 ## Template walkthrough
 
@@ -47,11 +47,13 @@ When the RFC adds or changes fields:
 - Use the **next free** folder number (scan `rfcs/text/`; duplicates get fixed at merge per template notes).
 - Align filenames with affected field sets (e.g. `faas.yml`, `gen_ai.yaml`) for reviewer navigation.
 
-## OTel alignment (donation period)
+## OTel alignment (optional)
 
-- Prefer names/types compatible with [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions).
-- Call out **match**, **equivalent**, **related**, **conflict** explicitly; plan parallel semconv PR if needed (does not need to merge before ECS RFC PR).
-- When implementing later in `schemas/*.yml`, each field needs valid `otel:` metadata per [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+ECS does not actively donate fields to OpenTelemetry Semantic Conventions at this time. However, ECS tracks relationships between its fields and OTel semconv via `otel:` metadata tags in `schemas/*.yml`.
+
+- When a new or changed field has a clear OTel semconv counterpart, adding an `otel:` block (with `relation: match | equivalent | related | conflict | na`) is encouraged but **not required**.
+- The `otel:` metadata is used to generate alignment documentation — it is not a gate for merging.
+- If unsure whether an OTel mapping applies, omit it; it can be added later.
 
 ## Maturity choice (alpha vs beta)
 
@@ -72,9 +74,9 @@ Promotion after merge is **out of band** from the RFC (team process per PROCESS.
 - **GenAI security fields:** [rfcs/text/0050-gen_ai-security-fields.md](../../../rfcs/text/0050-gen_ai-security-fields.md).
 - Use these for **structure** (fields, usage, source data, concerns), not for **stage** metadata.
 
-## Handoff to implementation
+## Implementation in the RFC PR
 
-After approval, contributors implement in `schemas/*.yml`, run **`make`**, add **CHANGELOG.next.md**, and open or update a normal schema PR if the RFC did not already include merged YAML.
+The RFC PR itself must include the schema implementation: `schemas/*.yml` changes, `make`-generated artifacts, and a **CHANGELOG.next.md** entry. There is no separate "handoff" — proposal and schema land together.
 
 ## Related
 

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -72,7 +72,6 @@ Promotion after merge is **out of band** from the RFC (team process per PROCESS.
 
 - **FaaS + service reuse:** [rfcs/text/0027-faas-fields.md](../../../rfcs/text/0027-faas-fields.md) + folder `rfcs/text/0027/`.
 - **GenAI security fields:** [rfcs/text/0050-gen_ai-security-fields.md](../../../rfcs/text/0050-gen_ai-security-fields.md).
-- Use these for **structure** (fields, usage, source data, concerns), not for **stage** metadata.
 
 ## Implementation in the RFC PR
 

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -76,7 +76,7 @@ Promotion after merge is **out of band** from the RFC (team process per PROCESS.
 
 ## Implementation in the RFC PR
 
-The RFC PR itself must include the schema implementation: `schemas/*.yml` changes, `make`-generated artifacts, and a **CHANGELOG.next.md** entry. There is no separate "handoff" — proposal and schema land together.
+The RFC PR itself should include the schema implementation: `schemas/*.yml` changes, `make`-generated artifacts, and a **CHANGELOG.next.md** entry. There is no separate "handoff" — proposal and schema land together.
 
 ## Related
 

--- a/.agents/skills/ecs-rfc-guide/SKILL.md
+++ b/.agents/skills/ecs-rfc-guide/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ecs-rfc-guide
+description: >-
+  Guides contributors through the Elastic Common Schema (ECS) RFC (Proposal)
+  process: template sections, target maturity (alpha/beta), rfcs/text artifacts,
+  and OTel alignment. Use when a change needs an RFC, when drafting or
+  reviewing RFC PRs, or when the user asks how to propose new ECS field sets or
+  substantial schema changes.
+---
+
+# ECS RFC (Proposal) guide
+
+## When this applies
+
+Use after **ecs-pr-triage** (or equivalent judgment) says **Needs RFC**, or when the user is starting a **new field set**, **breaking** change, **novel use case**, or **ECS-wide** design.
+
+Authoritative process: [rfcs/PROCESS.md](../../../rfcs/PROCESS.md). Template: [rfcs/0000-rfc-template.md](../../../rfcs/0000-rfc-template.md). High-level triggers: [rfcs/README.md](../../../rfcs/README.md).
+
+## Current process (short)
+
+1. Single **Proposal** stage — template must keep `Stage: **Proposal**`.
+2. Contributor opens a **PR** that adds the RFC markdown under `rfcs/` (name like `0000-<dash-separated-name>.md` until numbered).
+3. Specify **Target maturity:** `alpha`, `beta`, or `mixture` (see [Field stability](../../../docs/reference/ecs-principles-design.md#_field_stability)).
+4. ECS team reviews holistically; on approval they assign the **RFC number** and merge.
+5. Schema landings at agreed maturity may follow in the same or follow-up PRs (per team practice).
+
+## Template walkthrough
+
+Copy [rfcs/0000-rfc-template.md](../../../rfcs/0000-rfc-template.md). Remove HTML comments as sections are filled.
+
+| Section | What “good” looks like |
+|--------|-------------------------|
+| **Summary** | 2–5 sentences: what, why, impact. |
+| **Usage** | End-to-end: producer → storage → queries/dashboards/detections. |
+| **Fields** | Every proposed field: name, type, description, level/maturity, example. Prefer YAML blocks. If `object`/`flattened` without children, justify shape and conflict avoidance (see [schemas/README.md](../../../schemas/README.md)). |
+| **Source data** | ≥2 real examples (JSON/logs); link or place large payloads under `rfcs/text/<n>/`. |
+| **Scope of impact** | Ingestion (Beats/Agents), Kibana/apps, ECS repo (docs/tooling). |
+| **Concerns** | Risks + **resolved** mitigations; OTel overlap; naming; adoption. |
+| **People** | Author, SMEs, reviewers. |
+| **References** | Prior art, semconv links, related issues/PRs. |
+
+## `rfcs/text/<number>/` folder
+
+When the RFC adds or changes fields:
+
+- Create **`rfcs/text/<number>/`** with standalone **YAML** snippets, large JSON examples, or mappings — especially when the markdown would be huge.
+- Use the **next free** folder number (scan `rfcs/text/`; duplicates get fixed at merge per template notes).
+- Align filenames with affected field sets (e.g. `faas.yml`, `gen_ai.yaml`) for reviewer navigation.
+
+## OTel alignment (donation period)
+
+- Prefer names/types compatible with [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions).
+- Call out **match**, **equivalent**, **related**, **conflict** explicitly; plan parallel semconv PR if needed (does not need to merge before ECS RFC PR).
+- When implementing later in `schemas/*.yml`, each field needs valid `otel:` metadata per [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+## Maturity choice (alpha vs beta)
+
+- **Alpha** — earlier, may change more; good for exploratory or fast-moving domains.
+- **Beta** — clearer adoption path; still subject to change before GA.
+- **Mixture** — some fields alpha, some beta; explain per field or group.
+
+Promotion after merge is **out of band** from the RFC (team process per PROCESS.md).
+
+## PR hygiene
+
+- Link the **Proposal PR** at the bottom of the RFC (`### RFC Pull Requests`).
+- Do **not** replace process with old multi-stage labels found in historical RFCs under `rfcs/text/*.md`; those are legacy examples only.
+
+## Example RFCs (depth reference)
+
+- **FaaS + service reuse:** [rfcs/text/0027-faas-fields.md](../../../rfcs/text/0027-faas-fields.md) + folder `rfcs/text/0027/`.
+- **GenAI security fields:** [rfcs/text/0050-gen_ai-security-fields.md](../../../rfcs/text/0050-gen_ai-security-fields.md).
+- Use these for **structure** (fields, usage, source data, concerns), not for **stage** metadata.
+
+## Handoff to implementation
+
+After approval, contributors implement in `schemas/*.yml`, run **`make`**, add **CHANGELOG.next.md**, and open or update a normal schema PR if the RFC did not already include merged YAML.
+
+## Related
+
+- Triage and routing: **ecs-pr-triage** skill; [ecs-contribution-routing rule](../../rules/ecs-contribution-routing.mdc).
+- YAML details: [ecs-schema-standards rule](../../rules/ecs-schema-standards.mdc).


### PR DESCRIPTION
## Summary

- Add agent skills and rules under `.agents/` to enable automated PR triage for incoming ECS contributions.
- The triage agent (triggered via GitHub Actions on each new PR) classifies changes as **Direct PR**, **Needs RFC**, or **Needs Discussion**, checks PR completeness, and produces a structured report.
- This reduces contributor confusion about which process to follow and ensures the right level of scrutiny is applied to each change.

## What's included

### Rules (`.agents/rules/`)

| File | Scope | Purpose |
|------|-------|---------|
| `ecs-contribution-routing.mdc` | Always apply | Foundational context: direct PR vs RFC criteria, OTel donation alignment, links to authoritative docs |
| `ecs-schema-standards.mdc` | `schemas/**/*.yml` | Field set/field attribute requirements, `object`/`flattened` guidance, OTel `otel:` blocks, `--strict` constraints |
| `ecs-pr-completeness.mdc` | On-demand | PR template sections, CHANGELOG entry, generated artifacts, CLA, field quality checklist |

### Skills (`.agents/skills/`)

| Skill | Purpose |
|-------|---------|
| **ecs-pr-triage** | Autonomous triage agent — inventories the PR diff and metadata provided by GitHub Actions, walks a classification decision tree, checks completeness, and produces a Triage Report. Includes `classification-rules.md` (decision tree) and `report-template.md` (output format). |
| **ecs-rfc-guide** | Guides contributors through the RFC (Proposal) process when triage determines an RFC is needed — template walkthrough, target maturity, `rfcs/text/` folder, OTel alignment, example RFCs. |

### Classification logic

The triage agent routes PRs using a three-tier decision tree:

1. **Needs RFC** — new top-level fieldsets, breaking changes, novel use cases, ECS-wide scope, >10 new fields
2. **Needs Discussion** — moderate additions (3–10 fields), new categorization `allowed_values`, maturity promotions
3. **Direct PR** — bugfixes, small additive extensions, tooling, docs, CI, changelog

Default: when borderline, prefer RFC/discussion over under-triaging.

---

#### Commit Message
<!-- This will be used as the commit message when merging the PR. Please clearly explain what change is being changed and why. -->

Add agent skills and rules for automatic PR triage