### PR TITLE
Add Buildkite CI pipeline for tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+steps:
+  - label: ":python: Run tests (make check yamllint)"
+    key: tests
+    command: ".buildkite/scripts/run-tests.sh"
+    agents:
+      image: "docker.elastic.co/ci-agent-images/pipelib:0.27.0@sha256:d1713778d27e0b6208f59ba8761f04ef033af4c4237cb2614a09d38584c5ff88"
+      cpu: "2"
+      memory: "2G"

--- a/.buildkite/scripts/run-tests.sh
+++ b/.buildkite/scripts/run-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+git config --global --add safe.directory "$PWD"
+git fetch --prune --unshallow --tags || true
+
+make check yamllint

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ecs
+  description: Elastic Common Schema
+spec:
+  type: library
+  owner: group:ecs
+  lifecycle: production
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-ecs
+  description: ECS unit tests and lint checks
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/ecs
+spec:
+  type: buildkite-pipeline
+  owner: group:ecs
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: ecs
+      description: ECS unit tests and lint checks
+    spec:
+      repository: elastic/ecs
+      pipeline_file: ".buildkite/pipeline.yml"
+      branch_configuration: "main 8.* 9.* 10.*"
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main !8.* !9.*'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main !8.* !9.*'
+      provider_settings:
+        build_pull_requests: true
+        build_pull_request_forks: false
+        build_tags: false
+      teams:
+        ecs:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
## Summary

Add a Buildkite pipeline to run `make check yamllint` (the same command as the
existing GHA `test.yml` workflow), provisioned via Terrazzo from `catalog-info.yaml`.

The existing GitHub Actions test workflow is intentionally kept running in parallel
until Buildkite is confirmed green, then will be removed in a follow-up PR.

## What's included

- `.buildkite/pipeline.yml` — single test step on `pipelib:0.27.0`
- `.buildkite/scripts/run-tests.sh` — wrapper that runs `make check yamllint`
- `catalog-info.yaml` — registers the `ecs` Backstage Component and `buildkite-pipeline-ecs` Resource

## What happens after merge

1. Terrazzo provisions the `ecs` pipeline in Buildkite (minutes to ~30 min).
2. The merge commit triggers the first BK build on `main`.
3. Once green, add `buildkite/ecs` as a required status check on `main`.
4. Follow-up PR removes `.github/workflows/test.yml` and drops the old `Unit Tests` required check.

## Pipeline config choices

- **`branch_configuration: "main 8.* 9.* 10.*"`** — covers all active release branches; excludes frozen `1.*` branches.
- **`skip_intermediate_builds` / `cancel_intermediate_builds`** — enabled on topic branches only; long-lived branches keep every build.
- **No `filter_condition` yet** — deferred until `buildkite-pr-bot` is wired up (separate PR to `elastic/infra` + webhook config needed first).
- **No `.buildkite/pull-requests.json` yet** — same reason; comment triggers (`/test`) and changeset-based skips arrive in a follow-up.