### PR TITLE
fix: publish link index for release branches

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,3 +14,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
+      use-release-branches: true


### PR DESCRIPTION
## Summary

- Adds `use-release-branches: true` to the `docs-deploy` workflow so that semver release branches (e.g. `9.4`) upload their `links.json` to S3 and appear in the central `link-index.json`
- Without this flag, the reusable `elastic/docs-actions` workflow only triggers link index updates for the default branch (`main`), not semver release branches
- This is why `ecs/9.4` was missing from the link index while `beats/9.4` and `logstash/9.4` were present — those repos already pass this flag

## Test plan

- [ ] Merge and backport to `9.4`
- [ ] Re-run docs-build → docs-deploy on the `9.4` branch
- [ ] Verify `elastic/ecs/9.4/links.json` appears in S3
- [ ] Verify `ecs` → `9.4` entry appears in `link-index.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)