### PR TITLE
fix: publish link index for release branches (backport #2642)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,3 +14,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
+      use-release-branches: true


### PR DESCRIPTION
Add `use-release-branches: true` to the docs-deploy workflow so that semver release branches (e.g. 9.4) upload their links.json to S3 and appear in the central link-index.json. Without this flag only the default branch (main) triggers link index updates.

Backport of #2642