### PR TITLE
[RFC 0045] Define vulnerability.status as an enum

### DIFF
--- a/rfcs/text/0045-additional-vulnerability-fields.md
+++ b/rfcs/text/0045-additional-vulnerability-fields.md
@@ -38,7 +38,7 @@ The `vulnerabilities` fields being proposed are as follows:
 | `vulnerability.patch.name` | text | Name of the patch |
 | `vulnerability.patch.code` | keyword | Associated patch code for example ESA-2020-13 |
 | `vulnerability.evidence` | text | A demonstration of the validity of a vulnerability claim, e.g. app.any.run replaying the exploitation of the vulnerability. |
-| `vulnerability.status` | keyword | The status field helps security teams track vulnerabilities, prioritize actions, and communicate their progress effectively. Examples- open/ignored/patched/mitigated/false_positive/risk_accepted/reopened..|
+| `vulnerability.status` | keyword (enum: `open`, `fixed`, `reopened`, `unknown`) | Lifecycle state of a vulnerability finding on an asset. Integrations map vendor-specific values to one of these four: `open` (present), `fixed` (remediated), `reopened` (reappeared after fix), `unknown` (cannot determine).|
 | `vulnerability.tags` | keyword | This is different from cloud provider assigned resource tags, this is specifically for vulnerability. Vulnerability tags serve as a way to add custom metadata to vulnerabilities, enhancing their context and aiding in search and automation. |
 | `vulnerability.first_found` | date | First time a vulnerability was found on the asset, in ISO 8601 format: 2016-05-23T08:05:34.853Z |
 | `vulnerability.last_found` | date | Last time a vulnerability was found on the asset, in ISO 8601 format: 2016-05-23T08:05:34.853Z |


### PR DESCRIPTION
_To be closed in favour of https://github.com/elastic/ecs/pull/2655_

----

<!-- Thanks for contributing to Elastic ECS! To help us review your PR effectively and efficiently, please fill out the following sections.

Before submitting, please ensure you have:

Read the [ECS Contribution Guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md).

Signed the [Contributor License Agreement (CLA)](https://www.elastic.co/contributor-agreement) if you haven't already.

Ensured your changes align with the [ECS Guidelines and Best Practices](https://www.elastic.co/docs/reference/ecs/ecs-guidelines).

Filled in all of the sections below. -->

#### 1. What does this PR do?

Updates the `vulnerability.status` field definition in RFC 0045 to declare it as an enum with four constrained values (`open`, `fixed`, `reopened`, `unknown`) instead of a free-text keyword with seven example values.

Ref: elastic/security-team#17210

#### 2. Which ECS fields are affected/introduced?

- `vulnerability.status` (existing, proposed in RFC 0045) — changed from a free-text keyword to an enumerated keyword. The field captures the lifecycle state of a vulnerability finding on an asset, enabling the CDR Vulnerability Findings page to filter out remediated findings by default.

#### 3. Why is this change necessary?

The CDR Vulnerability Findings model assumes every document in the `vulnerability_latest` index is an open vulnerability. When integrations consume incremental/delta APIs (e.g. Microsoft Defender's `SoftwareVulnerabilityChangesByMachine`), remediated ("Fixed") records flow into the latest index and are displayed as open findings. A constrained enum lets the Kibana Findings page filter on `NOT vulnerability.status: fixed` by default — the same pattern used by `result.evaluation` (`passed`/`failed`/`unknown`) for misconfiguration findings.

The original RFC listed seven example values including triage dispositions (`ignored`, `false_positive`, `risk_accepted`) that describe human workflow decisions, not whether the vulnerability is technically present. Mixing lifecycle and disposition in one field makes filtering unreliable — a vulnerability marked `risk_accepted` is still open. CrowdStrike's API already separates these concerns: `status` for lifecycle vs. `suppression_info.reason` for disposition.

The four proposed values are well-supported across vendors:
- `open`: MS Defender New/Updated, Qualys New/Active, Tenable OPEN, CrowdStrike open, Wiz OPEN
- `fixed`: MS Defender Fixed, Qualys Fixed, Tenable FIXED, CrowdStrike closed, Wiz RESOLVED
- `reopened`: Qualys Re-Opened, Tenable REOPENED, CrowdStrike reopen
- `unknown`: fallback for full-snapshot integrations that do not provide lifecycle data

#### 4. Have you added/updated documentation?

N/A — the change is a single-line update to the field description within the RFC itself.

#### 5. Have you built ECS and committed any newly generated files?

NO — this change modifies only the RFC markdown, not the schema YAML or generated files.

#### 6. Have you run the ECS validation tests locally?

NO — no schema or code changes; RFC text only.

#### 7. Anything else for the reviewers?

This is intentionally a minimal change — just constraining the enum values on an existing proposed field. The broader question of whether triage dispositions (`false_positive`, `risk_accepted`, etc.) should be modelled in ECS is deferred to a future field (e.g. `vulnerability.disposition`). Keeping lifecycle and disposition separate follows the precedent set by CrowdStrike's API and avoids the filtering ambiguity that a mixed field would create.


---

#### Commit Message
<!-- This will be used as the commit message when merging the PR. Please clearly explain what change is being changed and why. -->

```
[RFC 0045] Define vulnerability.status as an enum

Constrain vulnerability.status to four values: open, fixed, reopened,
unknown. The original RFC listed seven free-text examples including
triage dispositions (ignored, false_positive, risk_accepted) that
describe human workflow decisions, not whether the vulnerability is
technically present on the asset.

The four lifecycle values are sufficient for the CDR Vulnerability
Findings page to filter out remediated findings by default (NOT
vulnerability.status: fixed), matching how result.evaluation (passed,
failed, unknown) works for misconfiguration findings.

The values are well-supported across vendors:
- open:     MS Defender New/Updated, Qualys New/Active, Tenable OPEN,
            CrowdStrike open, Wiz OPEN
- fixed:    MS Defender Fixed, Qualys Fixed, Tenable FIXED,
            CrowdStrike closed, Wiz RESOLVED
- reopened: Qualys Re-Opened, Tenable REOPENED, CrowdStrike reopen
- unknown:  fallback for full-snapshot integrations with no lifecycle

Triage dispositions (false_positive, risk_accepted, etc.) belong in a
separate field -- CrowdStrike already separates these via
suppression_info.reason. Mixing lifecycle and disposition in one field
makes filtering unreliable: a vulnerability marked risk_accepted is
still open.

Ref: elastic/security-team#17210
```

