### PR TITLE
feat(schema): add namespace field to service schema

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+- Add `namespace` field to `service` schema. #0000
+
 #### Improvements
 
 #### Deprecated

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,7 +16,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-- Add `namespace` field to `service` schema. #0000
+- Add `namespace` field to `service` schema. #2688
 
 #### Improvements
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -13029,6 +13029,34 @@
         field if no name is specified.'
       example: elasticsearch-metrics
       default_field: false
+    - name: origin.namespace
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A namespace for `service.name`.
+
+        Namespace distinguishes a group of related services, for example the team,
+        product line, or business unit that owns them. Unlike `service.name`, which
+        identifies one service, `service.namespace` identifies the group it belongs
+        to. This lets services be filtered, dashboarded, or access-controlled by owning
+        group rather than by individual name, and disambiguates `service.name` values
+        that are reused across different groups.
+
+        `service.namespace` is different from `service.type`. Take the Elasticsearch
+        cluster behind a streaming application called Elastiflix: `service.namespace`
+        is `elastiflix`, `service.name` is `elastiflix-es`, and `service.type` is
+        `elasticsearch`. The API and web frontend that make up the rest of Elastiflix
+        share that same `service.namespace`, but carry their own `service.name` and
+        `service.type` values. Namespace says which application or team a service
+        belongs to, type says what the service is built on, and one `service.type`
+        such as `elasticsearch` can appear under many different namespaces.
+
+        `service.namespace` is also independent of `service.environment`. The Elastiflix
+        Elasticsearch cluster above could have `service.environment` set to `development`,
+        and the same `service.namespace` and `service.name` would apply just as well
+        if that cluster were running in `production`.'
+      example: elastiflix
+      default_field: false
     - name: origin.node.name
       level: extended
       type: keyword
@@ -13556,6 +13584,34 @@
         name. For Beats the `service.name` is by default a copy of the `service.type`
         field if no name is specified.'
       example: elasticsearch-metrics
+      default_field: false
+    - name: target.namespace
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A namespace for `service.name`.
+
+        Namespace distinguishes a group of related services, for example the team,
+        product line, or business unit that owns them. Unlike `service.name`, which
+        identifies one service, `service.namespace` identifies the group it belongs
+        to. This lets services be filtered, dashboarded, or access-controlled by owning
+        group rather than by individual name, and disambiguates `service.name` values
+        that are reused across different groups.
+
+        `service.namespace` is different from `service.type`. Take the Elasticsearch
+        cluster behind a streaming application called Elastiflix: `service.namespace`
+        is `elastiflix`, `service.name` is `elastiflix-es`, and `service.type` is
+        `elasticsearch`. The API and web frontend that make up the rest of Elastiflix
+        share that same `service.namespace`, but carry their own `service.name` and
+        `service.type` values. Namespace says which application or team a service
+        belongs to, type says what the service is built on, and one `service.type`
+        such as `elasticsearch` can appear under many different namespaces.
+
+        `service.namespace` is also independent of `service.environment`. The Elastiflix
+        Elasticsearch cluster above could have `service.environment` set to `development`,
+        and the same `service.namespace` and `service.name` would apply just as well
+        if that cluster were running in `production`.'
+      example: elastiflix
       default_field: false
     - name: target.node.name
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1807,6 +1807,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.6.0-dev,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 9.6.0-dev,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 9.6.0-dev,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
+9.6.0-dev,true,service,service.origin.namespace,keyword,extended,,elastiflix,"Namespace grouping service.name values by team, product, or business unit."
 9.6.0-dev,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 9.6.0-dev,true,service,service.origin.node.role,keyword,extended,,background_tasks,Deprecated role (singular) of the service node.
 9.6.0-dev,true,service,service.origin.node.roles,keyword,extended,array,"[""ui"", ""background_tasks""]",Roles of the service node.
@@ -1875,6 +1876,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 9.6.0-dev,true,service,service.target.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 9.6.0-dev,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 9.6.0-dev,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
+9.6.0-dev,true,service,service.target.namespace,keyword,extended,,elastiflix,"Namespace grouping service.name values by team, product, or business unit."
 9.6.0-dev,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 9.6.0-dev,true,service,service.target.node.role,keyword,extended,,background_tasks,Deprecated role (singular) of the service node.
 9.6.0-dev,true,service,service.target.node.roles,keyword,extended,array,"[""ui"", ""background_tasks""]",Roles of the service node.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -23061,6 +23061,40 @@ service.origin.name:
   original_fieldset: service
   short: Name of the service.
   type: keyword
+service.origin.namespace:
+  beta: This field is beta and subject to change.
+  dashed_name: service-origin-namespace
+  description: 'A namespace for `service.name`.
+
+    Namespace distinguishes a group of related services, for example the team, product
+    line, or business unit that owns them. Unlike `service.name`, which identifies
+    one service, `service.namespace` identifies the group it belongs to. This lets
+    services be filtered, dashboarded, or access-controlled by owning group rather
+    than by individual name, and disambiguates `service.name` values that are reused
+    across different groups.
+
+    `service.namespace` is different from `service.type`. Take the Elasticsearch cluster
+    behind a streaming application called Elastiflix: `service.namespace` is `elastiflix`,
+    `service.name` is `elastiflix-es`, and `service.type` is `elasticsearch`. The
+    API and web frontend that make up the rest of Elastiflix share that same `service.namespace`,
+    but carry their own `service.name` and `service.type` values. Namespace says which
+    application or team a service belongs to, type says what the service is built
+    on, and one `service.type` such as `elasticsearch` can appear under many different
+    namespaces.
+
+    `service.namespace` is also independent of `service.environment`. The Elastiflix
+    Elasticsearch cluster above could have `service.environment` set to `development`,
+    and the same `service.namespace` and `service.name` would apply just as well if
+    that cluster were running in `production`.'
+  example: elastiflix
+  flat_name: service.origin.namespace
+  ignore_above: 1024
+  level: extended
+  name: namespace
+  normalize: []
+  original_fieldset: service
+  short: Namespace grouping service.name values by team, product, or business unit.
+  type: keyword
 service.origin.node.name:
   dashed_name: service-origin-node-name
   description: 'Name of a service node.
@@ -24035,6 +24069,40 @@ service.target.name:
   normalize: []
   original_fieldset: service
   short: Name of the service.
+  type: keyword
+service.target.namespace:
+  beta: This field is beta and subject to change.
+  dashed_name: service-target-namespace
+  description: 'A namespace for `service.name`.
+
+    Namespace distinguishes a group of related services, for example the team, product
+    line, or business unit that owns them. Unlike `service.name`, which identifies
+    one service, `service.namespace` identifies the group it belongs to. This lets
+    services be filtered, dashboarded, or access-controlled by owning group rather
+    than by individual name, and disambiguates `service.name` values that are reused
+    across different groups.
+
+    `service.namespace` is different from `service.type`. Take the Elasticsearch cluster
+    behind a streaming application called Elastiflix: `service.namespace` is `elastiflix`,
+    `service.name` is `elastiflix-es`, and `service.type` is `elasticsearch`. The
+    API and web frontend that make up the rest of Elastiflix share that same `service.namespace`,
+    but carry their own `service.name` and `service.type` values. Namespace says which
+    application or team a service belongs to, type says what the service is built
+    on, and one `service.type` such as `elasticsearch` can appear under many different
+    namespaces.
+
+    `service.namespace` is also independent of `service.environment`. The Elastiflix
+    Elasticsearch cluster above could have `service.environment` set to `development`,
+    and the same `service.namespace` and `service.name` would apply just as well if
+    that cluster were running in `production`.'
+  example: elastiflix
+  flat_name: service.target.namespace
+  ignore_above: 1024
+  level: extended
+  name: namespace
+  normalize: []
+  original_fieldset: service
+  short: Namespace grouping service.name values by team, product, or business unit.
   type: keyword
 service.target.node.name:
   dashed_name: service-target-node-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -26045,6 +26045,41 @@ service:
       original_fieldset: service
       short: Name of the service.
       type: keyword
+    service.origin.namespace:
+      beta: This field is beta and subject to change.
+      dashed_name: service-origin-namespace
+      description: 'A namespace for `service.name`.
+
+        Namespace distinguishes a group of related services, for example the team,
+        product line, or business unit that owns them. Unlike `service.name`, which
+        identifies one service, `service.namespace` identifies the group it belongs
+        to. This lets services be filtered, dashboarded, or access-controlled by owning
+        group rather than by individual name, and disambiguates `service.name` values
+        that are reused across different groups.
+
+        `service.namespace` is different from `service.type`. Take the Elasticsearch
+        cluster behind a streaming application called Elastiflix: `service.namespace`
+        is `elastiflix`, `service.name` is `elastiflix-es`, and `service.type` is
+        `elasticsearch`. The API and web frontend that make up the rest of Elastiflix
+        share that same `service.namespace`, but carry their own `service.name` and
+        `service.type` values. Namespace says which application or team a service
+        belongs to, type says what the service is built on, and one `service.type`
+        such as `elasticsearch` can appear under many different namespaces.
+
+        `service.namespace` is also independent of `service.environment`. The Elastiflix
+        Elasticsearch cluster above could have `service.environment` set to `development`,
+        and the same `service.namespace` and `service.name` would apply just as well
+        if that cluster were running in `production`.'
+      example: elastiflix
+      flat_name: service.origin.namespace
+      ignore_above: 1024
+      level: extended
+      name: namespace
+      normalize: []
+      original_fieldset: service
+      short: Namespace grouping service.name values by team, product, or business
+        unit.
+      type: keyword
     service.origin.node.name:
       dashed_name: service-origin-node-name
       description: 'Name of a service node.
@@ -27028,6 +27063,41 @@ service:
       normalize: []
       original_fieldset: service
       short: Name of the service.
+      type: keyword
+    service.target.namespace:
+      beta: This field is beta and subject to change.
+      dashed_name: service-target-namespace
+      description: 'A namespace for `service.name`.
+
+        Namespace distinguishes a group of related services, for example the team,
+        product line, or business unit that owns them. Unlike `service.name`, which
+        identifies one service, `service.namespace` identifies the group it belongs
+        to. This lets services be filtered, dashboarded, or access-controlled by owning
+        group rather than by individual name, and disambiguates `service.name` values
+        that are reused across different groups.
+
+        `service.namespace` is different from `service.type`. Take the Elasticsearch
+        cluster behind a streaming application called Elastiflix: `service.namespace`
+        is `elastiflix`, `service.name` is `elastiflix-es`, and `service.type` is
+        `elasticsearch`. The API and web frontend that make up the rest of Elastiflix
+        share that same `service.namespace`, but carry their own `service.name` and
+        `service.type` values. Namespace says which application or team a service
+        belongs to, type says what the service is built on, and one `service.type`
+        such as `elasticsearch` can appear under many different namespaces.
+
+        `service.namespace` is also independent of `service.environment`. The Elastiflix
+        Elasticsearch cluster above could have `service.environment` set to `development`,
+        and the same `service.namespace` and `service.name` would apply just as well
+        if that cluster were running in `production`.'
+      example: elastiflix
+      flat_name: service.target.namespace
+      ignore_above: 1024
+      level: extended
+      name: namespace
+      normalize: []
+      original_fieldset: service
+      short: Namespace grouping service.name values by team, product, or business
+        unit.
       type: keyword
     service.target.node.name:
       dashed_name: service-target-node-name

--- a/generated/elasticsearch/composable/component/service.json
+++ b/generated/elasticsearch/composable/component/service.json
@@ -697,6 +697,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "namespace": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "node": {
                   "properties": {
                     "name": {
@@ -1066,6 +1070,10 @@
                   "type": "keyword"
                 },
                 "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "namespace": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -8556,6 +8556,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "namespace": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "node": {
                 "properties": {
                   "name": {
@@ -8925,6 +8929,10 @@
                 "type": "keyword"
               },
               "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "namespace": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -100,6 +100,42 @@
       otel:
         - relation: match
 
+    - name: namespace
+      level: extended
+      type: keyword
+      short: Namespace grouping service.name values by team, product, or business unit.
+      beta: This field is beta and subject to change.
+      example: elastiflix
+      description: >
+        A namespace for `service.name`.
+
+        Namespace distinguishes a group of related services, for example
+        the team, product line, or business unit that owns them. Unlike
+        `service.name`, which identifies one service, `service.namespace`
+        identifies the group it belongs to. This lets services be
+        filtered, dashboarded, or access-controlled by owning group rather
+        than by individual name, and disambiguates `service.name` values
+        that are reused across different groups.
+
+        `service.namespace` is different from `service.type`. Take the
+        Elasticsearch cluster behind a streaming application called
+        Elastiflix: `service.namespace` is `elastiflix`, `service.name`
+        is `elastiflix-es`, and `service.type` is `elasticsearch`. The
+        API and web frontend that make up the rest of Elastiflix share
+        that same `service.namespace`, but carry their own `service.name`
+        and `service.type` values. Namespace says which application or
+        team a service belongs to, type says what the service is built
+        on, and one `service.type` such as `elasticsearch` can appear
+        under many different namespaces.
+
+        `service.namespace` is also independent of `service.environment`.
+        The Elastiflix Elasticsearch cluster above could have
+        `service.environment` set to `development`, and the same
+        `service.namespace` and `service.name` would apply just as well
+        if that cluster were running in `production`.
+      otel:
+        - relation: match
+
     - name: node.name
       level: extended
       type: keyword


### PR DESCRIPTION
#### 1. What does this PR do?

Add `service.namespace` to the service fieldset as a keyword field that groups related `service.name` values under a common owner, such as a team, product line, or business unit.

- Implements RFC 0057

#### 2. Which ECS fields are affected/introduced?

- `service.namespace`

See [RFC 0057](#2680)

#### 3. Why is this change necessary?

See [RFC 0057](#2680)

#### 4. Have you added/updated documentation?
YES

#### 5. Have you built ECS and committed any newly generated files?
YES

#### 6. Have you run the ECS validation tests locally?
YES

#### 7. Anything else for the reviewers?
N/A

---

#### Commit Message

```
feat(schema): add namespace field to service schema

Add `service.namespace` to the service fieldset as a keyword
field that groups related `service.name` values under a common
owner, such as a team, product line, or business unit.

- Implements RFC 0057
```